### PR TITLE
docs: refresh README and landing page to 135 agents and add Vista

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # AI Agent Skills
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Agents](https://img.shields.io/badge/Agents-134-blue.svg)]()
+[![Agents](https://img.shields.io/badge/Agents-135-blue.svg)]()
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 A skill collection that enables collaborative development with a team of specialized AI agents.
 
 ## Features
 
-- **134 Specialized Agents** - Covering bug investigation, testing, security, UI/UX, AI/ML, observability, and more
+- **135 Specialized Agents** - Covering bug investigation, testing, security, UI/UX, AI/ML, observability, and more
 - **Nexus Orchestrator** - Analyzes tasks and automatically designs optimal agent chains
 - **Platform Agnostic** - Works with Claude Code, Codex CLI, Gemini CLI, and others
 
@@ -35,7 +35,7 @@ git clone https://github.com/simota/agent-skills.git /path/to/your/skills
 
 ## Overview
 
-This repository contains 134 specialized AI agents covering various aspects of software development. Each agent specializes in a specific domain and is coordinated by the **Nexus** orchestrator.
+This repository contains 135 specialized AI agents covering various aspects of software development. Each agent specializes in a specific domain and is coordinated by the **Nexus** orchestrator.
 
 ## Agent Catalog
 
@@ -117,6 +117,7 @@ This repository contains 134 specialized AI agents covering various aspects of s
 | **Sentinel** | _"Security is not a feature. It's a responsibility."_ - Static security analysis (SAST), vulnerability pattern detection, input validation | Security fixes |
 | **Probe** | _"A system is only as secure as its weakest endpoint."_ - Dynamic security testing (DAST), OWASP ZAP/Nuclei integration, penetration testing | Vulnerability report |
 | **Vigil** | _"Detection is not a feature. It is the immune system of your infrastructure."_ - Detection Engineering agent. Sigma/YARA rule design, detection coverage mapping (MITRE ATT&CK), threat hunting hypothesis design, Purple Team Blue side execution, Detection-as-Code CI/CD integration | Detection rules, coverage maps |
+| **Vista** | _"Tests you can't see, you don't trust. Tests you trust, you ship."_ - Test intelligence visualization specialist. Turns junit.xml/lcov/allure/playwright/CTRF/OTel test data into coverage heatmaps, traceability matrices, test-shape views (Pyramid/Trophy/Honeycomb/Diamond/Cupcake/Hourglass/Ice-Cream-Cone), flake dashboards (Wilson lower-bound), mutation-overlaid coverage maps, AI-origin test risk lenses, regression timelines (E-Divisive change-points). Markdown + HTML dual-format output | Coverage heatmaps, test-shape views, flake dashboards |
 | **Judge** | _"Good code needs no defense. Bad code has no excuse."_ - Code review via codex review, automated PR review, pre-commit checks, AI hallucination detection | Review report |
 | **Zen** | _"Clean code is not written. It's rewritten."_ - Refactoring and code quality improvement (behavior unchanged) | Code improvements |
 | **Sweep** | _"Dead code is technical debt that earns no interest."_ - Unused file detection, dead code identification, orphaned file discovery, safe deletion proposals | Cleanup proposals |
@@ -812,7 +813,7 @@ skills/
 
 ### Single Agent Usage
 
-> Category-by-category examples for all 134 agents.
+> Category-by-category examples for all 135 agents.
 
 #### Orchestration
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,14 +1,14 @@
 # AI Agent Skills
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Agents](https://img.shields.io/badge/Agents-134-blue.svg)]()
+[![Agents](https://img.shields.io/badge/Agents-135-blue.svg)]()
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-🤖 134種類の専門AIエージェントチームによる協調開発を実現するスキルコレクション
+🤖 135種類の専門AIエージェントチームによる協調開発を実現するスキルコレクション
 
 ## ✨ Features
 
-- **134種類の専門エージェント** - バグ調査、テスト、セキュリティ、UI/UX、AI/ML、可観測性、インフラまで網羅
+- **135種類の専門エージェント** - バグ調査、テスト、セキュリティ、UI/UX、AI/ML、可観測性、インフラまで網羅
 - **Nexusオーケストレーター** - タスクを分析し最適なエージェントチェーンを自動設計
 - **プラットフォーム非依存** - Claude Code、Codex CLI、Gemini CLI等で動作
 
@@ -35,7 +35,7 @@ git clone https://github.com/simota/agent-skills.git /path/to/your/skills
 
 ## 📚 概要
 
-このリポジトリには、ソフトウェア開発の様々な側面を専門とする134種類のAIエージェントが含まれています。各エージェントは特定のドメインに特化しており、**Nexus**オーケストレーターによって統括・連携されます。
+このリポジトリには、ソフトウェア開発の様々な側面を専門とする135種類のAIエージェントが含まれています。各エージェントは特定のドメインに特化しており、**Nexus**オーケストレーターによって統括・連携されます。
 
 ## エージェント一覧
 
@@ -123,6 +123,7 @@ git clone https://github.com/simota/agent-skills.git /path/to/your/skills
 | **Siege** | _"Break it before users do. Fix it before they notice."_ - 高度テストスペシャリスト。負荷テスト（k6/Locust/Artillery）、契約テスト（Pact CDC）、カオスエンジニアリング、ミューテーションテスト、レジリエンスパターン検証 | テスト結果、レジリエンスレポート |
 | **Void** | _"The best code is the code that was never written."_ - YAGNI検証・スコープカット・機能プルーニング・複雑性削減提案。5つの存在検証問とCost-of-Keeping Scoreで不要な複雑性を特定 | 削減提案 |
 | **Vigil** | _"Detection is the first line of defense. Engineering is the last."_ - Detection Engineeringエージェント。Sigma/YARAルール設計、検出カバレッジマッピング、脅威ハンティング仮説設計、Detection-as-Code CI/CD統合 | 検出ルール、カバレッジマップ |
+| **Vista** | _"Tests you can't see, you don't trust. Tests you trust, you ship."_ - テスト知見の可視化スペシャリスト。junit.xml/lcov/allure/playwright/CTRF/OTelからカバレッジヒートマップ、トレーサビリティマトリクス、Test-Shape（Pyramid/Trophy/Honeycomb/Diamond/Cupcake/Hourglass/Ice-Cream-Cone）、フレーキーテストダッシュボード（Wilson下限）、ミューテーション重畳カバレッジ、AI起点テストリスクレンズ、リグレッションタイムライン（E-Divisive変化点）を生成。Markdown + HTML 二重出力 | カバレッジヒートマップ、Test-Shape、フレーキーダッシュボード |
 | **Mint** | _"Good tests deserve great data."_ - テストデータ＆フィクスチャ生成エージェント。ファクトリパターン設計、境界値データ生成、合成データ生成、シードデータ管理 | コード |
 | **Comply** | _"Trust is earned. Compliance is proven."_ - 規制コンプライアンス＆監査エージェント。SOC2/PCI-DSS/HIPAA/ISO 27001のコントロールマッピング、監査証跡設計、Policy as Code | レポート、チェックリスト |
 | **Breach** | _"Think like an attacker. Defend like an engineer."_ - レッドチームエンジニアリング。攻撃シナリオ設計、脅威モデリング、MITRE ATT&CK/OWASPフレームワーク、Purple Team演習、AI/LLMレッドチーミング | セキュリティ評価 |
@@ -799,7 +800,7 @@ skills/
 
 ### 単一エージェントの使用
 
-> カテゴリ別に全134エージェントの使用例を紹介します。
+> カテゴリ別に全135エージェントの使用例を紹介します。
 
 #### オーケストレーション
 

--- a/index.html
+++ b/index.html
@@ -3,16 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Agent Skills — 133超の専門AIエージェントが、あなたの開発チームになる</title>
-  <meta name="description" content="Claude Code / Codex CLI / Gemini CLI で動作するオープンソースのAIエージェントエコシステム。バグ調査、テスト、セキュリティ、UI/UX、AI/ML、インフラまで網羅する131超の専門エージェント。">
-  <meta property="og:title" content="Agent Skills — 133超の専門AIエージェントが、あなたの開発チームになる">
-  <meta property="og:description" content="133超の専門AIエージェントが、あなたの開発チームになる。Claude Code / Codex CLI / Gemini CLI 対応のオープンソースエコシステム。">
+  <title>Agent Skills — 135超の専門AIエージェントが、あなたの開発チームになる</title>
+  <meta name="description" content="Claude Code / Codex CLI / Gemini CLI で動作するオープンソースのAIエージェントエコシステム。バグ調査、テスト、セキュリティ、UI/UX、AI/ML、インフラまで網羅する135超の専門エージェント。">
+  <meta property="og:title" content="Agent Skills — 135超の専門AIエージェントが、あなたの開発チームになる">
+  <meta property="og:description" content="135超の専門AIエージェントが、あなたの開発チームになる。Claude Code / Codex CLI / Gemini CLI 対応のオープンソースエコシステム。">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://simota.github.io/agent-skills/">
   <meta property="og:locale" content="ja_JP">
   <meta property="og:site_name" content="Agent Skills">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Agent Skills — 133超の専門AIエージェントが、あなたの開発チームになる">
+  <meta name="twitter:title" content="Agent Skills — 135超の専門AIエージェントが、あなたの開発チームになる">
   <meta name="twitter:description" content="バグ調査、セキュリティ、UI/UX、リリース管理まで。オープンソースのAIエージェントエコシステム。">
   <meta property="og:image" content="https://simota.github.io/agent-skills/og-image.png">
   <meta property="og:image:width" content="1200">
@@ -25,7 +25,7 @@
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Agent Skills",
-      "description": "Open-source AI agent ecosystem for Claude Code, Codex CLI, and Gemini CLI. 133+ specialist agents covering investigation, implementation, testing, security, UI/UX, AI/ML, and infrastructure.",
+      "description": "Open-source AI agent ecosystem for Claude Code, Codex CLI, and Gemini CLI. 135+ specialist agents covering investigation, implementation, testing, security, UI/UX, AI/ML, and infrastructure.",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://simota.github.io/agent-skills/",
@@ -44,8 +44,8 @@
       "@context": "https://schema.org",
       "@type": "ItemList",
       "name": "AI Agent Catalog",
-      "description": "133+ specialist AI agents for software development",
-      "numberOfItems": 133,
+      "description": "135+ specialist AI agents for software development",
+      "numberOfItems": 135,
       "itemListElement": [
         { "@type": "ListItem", "position": 1, "name": "Nexus", "description": "Team orchestrator that decomposes requests and auto-designs optimal agent chains" },
         { "@type": "ListItem", "position": 2, "name": "Scout", "description": "Bug investigation, root cause analysis (RCA), and reproduction step identification" },
@@ -910,7 +910,7 @@ a:focus-visible, .btn:focus-visible, .filter-btn:focus-visible, .lang-btn:focus-
       <span class="dot"></span>
       Open Source — MIT License
     </div>
-    <h1 data-i18n="hero.title"><span class="accent">131+</span>の専門AIエージェントが、<br>あなたの開発チームになる</h1>
+    <h1 data-i18n="hero.title"><span class="accent">135+</span>の専門AIエージェントが、<br>あなたの開発チームになる</h1>
     <p data-i18n="hero.desc">バグ調査、セキュリティ監査、UI/UX、リリース管理まで — 開発のあらゆる領域を専門エージェントがカバー。Claude Code・Codex CLI・Gemini CLI で今日から使えるオープンソースエコシステム。</p>
     <div class="hero-copy-cmd">
       <code>git clone https://github.com/simota/agent-skills.git ~/.claude/skills</code>
@@ -1200,7 +1200,7 @@ a:focus-visible, .btn:focus-visible, .filter-btn:focus-visible, .lang-btn:focus-
     <div class="section-header fade-in">
       <div class="section-label">Agent Catalog</div>
       <h2 class="section-title" data-i18n="catalog.title">エージェントを探す</h2>
-      <p class="section-desc" data-i18n="catalog.desc">131超の専門エージェントをカテゴリやキーワードで絞り込めます</p>
+      <p class="section-desc" data-i18n="catalog.desc">135超の専門エージェントをカテゴリやキーワードで絞り込めます</p>
     </div>
     <div class="catalog-controls fade-in">
       <div class="catalog-search-row">
@@ -1319,7 +1319,7 @@ a:focus-visible, .btn:focus-visible, .filter-btn:focus-visible, .lang-btn:focus-
       </div>
     </div>
     <div style="text-align:center; margin-top:32px; padding-top:24px;">
-      <a href="#install" class="btn btn-primary" style="font-size:0.9rem;" data-i18n="footer.cta">100超のエージェントで開発を始める</a>
+      <a href="#install" class="btn btn-primary" style="font-size:0.9rem;" data-i18n="footer.cta">135超のエージェントで開発を始める</a>
     </div>
     <div class="footer-bottom">
       MIT License &copy; simota
@@ -1411,6 +1411,7 @@ const AGENTS = [
   { name: 'Mint', motto: 'Good tests need good data. Generate it by design.', description: 'テストデータ＆フィクスチャ生成。ファクトリパターン設計、境界値データ生成、合成データ生成、シードデータ管理', category: 'quality' },
   { name: 'Comply', motto: 'Compliance is not a checkbox. It is a culture.', description: '規制コンプライアンス＆監査。SOC2/PCI-DSS/HIPAA/ISO 27001等のコントロール実装', category: 'quality' },
   { name: 'Cloak', motto: "Privacy is not a feature. It's a right.", description: 'プライバシーエンジニアリング。PII検出・GDPR/CCPA準拠', category: 'quality' },
+  { name: 'Vista', motto: "Tests you can't see, you don't trust. Tests you trust, you ship.", description: 'テスト知見の可視化。junit.xml/lcov/allure/playwright/CTRF/OTelからカバレッジヒートマップ・Test-Shape・フレーキーダッシュボードを生成', category: 'quality' },
 
   // Implementation (4)
   { name: 'Builder', motto: 'Types are contracts. Code is a promise.', description: '型安全かつプロダクションレディな実装職人。TDD・CQRS対応', category: 'implementation' },
@@ -1655,7 +1656,7 @@ let currentLang = localStorage.getItem('lang') || 'ja';
 
 const TRANSLATIONS = {
   en: {
-    'hero.title': '<span class="accent">131+</span> Expert AI Agents<br>Become Your Dev Team',
+    'hero.title': '<span class="accent">135+</span> Expert AI Agents<br>Become Your Dev Team',
     'hero.desc': 'From bug investigation and security audits to UI/UX and release management — specialist agents cover every area of development. An open-source ecosystem for Claude Code, Codex CLI, and Gemini CLI.',
     'hero.cta': 'Get Started',
     'hero.github': 'View on GitHub',
@@ -1693,7 +1694,7 @@ const TRANSLATIONS = {
     'subcmd.benefit3.title': 'Progressive Disclosure',
     'subcmd.benefit3.desc': 'Maps naturally to the three-tier hierarchy: L1 frontmatter → L2 SKILL.md → L3 references. Scales cleanly.',
     'catalog.title': 'Find an Agent',
-    'catalog.desc': 'Filter 133+ specialist agents by category or keyword',
+    'catalog.desc': 'Filter 135+ specialist agents by category or keyword',
     'catalog.search': 'Search agents... (name, description, motto)',
     'catalog.empty': 'No matching agents found',
     'platforms.title': 'Multi-Platform Support',
@@ -1717,7 +1718,7 @@ const TRANSLATIONS = {
     'hero.cta': 'Learn How',
     'social.star': 'GitHub Star',
     'social.platform': 'Works with Claude Code / Codex CLI / Gemini CLI',
-    'footer.cta': 'Start building with 131+ agents',
+    'footer.cta': 'Start building with 135+ agents',
     'terminal.cmd': '/Nexus Fix the login bug',
     'terminal.analyzing': 'Analyzing task...',
     'terminal.chain': 'Chain designed:',
@@ -1895,15 +1896,15 @@ function setLanguage(lang) {
   const ogTitleEl = document.querySelector('meta[property="og:title"]');
   const ogDescEl = document.querySelector('meta[property="og:description"]');
   if (lang === 'en') {
-    titleEl.textContent = 'Agent Skills — 131+ Expert AI Agents Become Your Dev Team';
-    descEl.content = 'An open-source AI agent ecosystem for Claude Code, Codex CLI, and Gemini CLI. 133+ specialist agents covering bug investigation, testing, security, UI/UX, AI/ML, and infrastructure.';
+    titleEl.textContent = 'Agent Skills — 135+ Expert AI Agents Become Your Dev Team';
+    descEl.content = 'An open-source AI agent ecosystem for Claude Code, Codex CLI, and Gemini CLI. 135+ specialist agents covering bug investigation, testing, security, UI/UX, AI/ML, and infrastructure.';
     ogTitleEl.content = 'Agent Skills — AI Agent Ecosystem';
-    ogDescEl.content = '131+ expert AI agents become your dev team. An open-source agent ecosystem.';
+    ogDescEl.content = '135+ expert AI agents become your dev team. An open-source agent ecosystem.';
   } else {
-    titleEl.textContent = 'Agent Skills — 133超の専門AIエージェントが、あなたの開発チームになる';
-    descEl.content = 'Claude Code / Codex CLI / Gemini CLI で動作するオープンソースのAIエージェントエコシステム。バグ調査、テスト、セキュリティ、UI/UX、AI/ML、インフラまで網羅する131超の専門エージェント。';
+    titleEl.textContent = 'Agent Skills — 135超の専門AIエージェントが、あなたの開発チームになる';
+    descEl.content = 'Claude Code / Codex CLI / Gemini CLI で動作するオープンソースのAIエージェントエコシステム。バグ調査、テスト、セキュリティ、UI/UX、AI/ML、インフラまで網羅する135超の専門エージェント。';
     ogTitleEl.content = 'Agent Skills — AI Agent Ecosystem';
-    ogDescEl.content = '133超の専門AIエージェントが、あなたの開発チームになる。オープンソースのエージェントエコシステム。';
+    ogDescEl.content = '135超の専門AIエージェントが、あなたの開発チームになる。オープンソースのエージェントエコシステム。';
   }
 
   // Re-render dynamic content


### PR DESCRIPTION
## Summary

エージェント総数を実態の 135 に揃え、漏れていた **Vista**(Test intelligence visualization)をカタログに追加します。

## Changes

- **Vista 追加**: `README.md` / `README_ja.md` の Quality Assurance セクション、`index.html` の Quality カテゴリ agent 配列
- **エージェント数を 135 に統一**:
  - README.md / README_ja.md: バッジ・本文すべてを 135 へ
  - index.html: title / og:title / og:description / twitter:title / JSON-LD description / numberOfItems / hero / catalog desc / footer CTA / 英語 i18n / 動的タイトルスクリプト
- 既存の不整合(131+ / 133+ / 100超 が混在)を canonical な 135+ / 135超 に正規化

## Verification

- `find skills -name SKILL.md -not -path "_*"` の実数: **135**
- README/index.html の Vista 言及: 各ファイル 1 件以上で確認
- 残留 count strings(131/133/100超): grep でゼロ件

## Test plan

- [ ] index.html をブラウザで開き、JA/EN 切り替えでヒーロー・カタログ・フッターの数値が 135 になっていることを確認
- [ ] OGP / Twitter カード preview で 135 が表示されることを確認(meta タグレベル)
- [ ] README.md / README_ja.md の Quality Assurance テーブルに Vista が表示されること