### PR TITLE
feat(templates): add design feedback learning kit

### DIFF
--- a/_templates/design-feedback-kit/AGENT_GUIDE.md
+++ b/_templates/design-feedback-kit/AGENT_GUIDE.md
@@ -1,0 +1,79 @@
+# Agent Guide — running the loop & enforcing principles
+
+How AI agents operate this kit. Two responsibilities: (A) **run the learning loop** when feedback arrives, and (B) **enforce** accepted principles on every UI task.
+
+---
+
+## A. Running the loop
+
+Invoke via `/nexus` (this is the orchestration layer) or run the steps directly. Recommended chain:
+
+```
+CAPTURE → ANALYZE (voice ‖ echo ‖ palette) → REVIEW (human, AskUserQuestion) → PROMOTE (muse / vision / lore) → ENFORCE
+```
+
+### Step 2 — ANALYZE (the only heavy step)
+Spawn in parallel, then synthesize:
+- **`voice`** — cluster raw feedback into themes; sentiment + frequency. Input: all `feedback-log.md` entries with `status: new`.
+- **`echo`** — cognitive walkthrough of the affected flow; emotional-friction score; pinpoint the confusion moment.
+- **`palette`** (optional) — usability/a11y lens on the specific surface.
+
+**Promotion threshold** — only draft a principle when the theme has **≥2 independent feedback items**, OR a **single high-severity** item (data loss, blocked task, a11y blocker). Below threshold: mark feedback `status: analyzed` and leave it to accumulate — do not draft a principle from a lone low-severity opinion.
+
+For themes that clear the threshold, synthesis produces a **draft principle** using `_templates/principle-entry.md` with `status: proposed`. Decide scope:
+- True on web **and** iOS **and** Android → `core`.
+- Platform-specific → the matching layer (`frontend`/`ios`/`android`) as a **delta** (never duplicate a core rule).
+
+Before drafting, scan `principles/INDEX.md` by tag — if a matching principle exists, propose an **edit** to it rather than a new entry. Mark the source feedback `status: analyzed` and link the draft.
+
+### Step 3 — REVIEW (human gate — mandatory, never auto-approved)
+**This gate is never skipped — not even under `/nexus` AUTORUN / AUTORUN_FULL.** An agent must not self-promote a draft to `accepted`; promotion requires an explicit human decision here. Treat REVIEW as an Ask-First checkpoint regardless of execution mode.
+
+Present each draft via `AskUserQuestion`:
+```
+Proposed principle: <title>
+Statement: <rule>
+From feedback: <FB ids + 1-line summary>
+Scope: <core|frontend|ios|android>
+→ [Accept] [Edit] [Reject]
+```
+- **Accept** → set `status: accepted`, proceed to PROMOTE.
+- **Edit** → capture changes, re-present.
+- **Reject** → mark source feedback `status: rejected` + `Reject reason`; do not add a principle.
+
+> A single complaint is a signal, not a law. Default to caution: prefer Edit/Reject over promoting an over-broad rule from one data point. `lore` flags drafts that **contradict or duplicate** existing principles before review.
+
+**Conflict resolution** — if a draft contradicts an existing `accepted` principle (beyond the core-vs-platform delta rule), the human decides at REVIEW: (a) **supersede** — deprecate the old (move to its file's `## Archive`, set `Superseded by:`) and accept the new; (b) **scope-narrow** — keep both, restricting one to a platform/context; or (c) **reject** the draft. Never leave two accepted principles in direct conflict.
+
+### Step 4 — PROMOTE
+- Append the accepted entry to the correct `principles/*.md` using a kebab-case slug ID (`P-<scope>-<slug>`) — no shared counter, so concurrent promotions never collide.
+- Add the principle's row to `principles/INDEX.md` (by-tag + by-scope).
+- Mark source feedback `status: promoted` + `Promoted to: P-<scope>-<slug>`.
+- If the principle has a **quantitative** part (spacing, color, type scale, durations), encode it as a design token via `muse` so it's machine-enforceable, and record the token name in the entry's `Token:` field.
+- Add a reference mockup to `mockups/` (Do, and Before/After if applicable) — `forge` for HTML, `frame` for Figma bridge.
+
+---
+
+## B. Enforcement (every UI task, going forward)
+
+**Before** any design or frontend/native UI work, an agent MUST:
+1. Scan `design/principles/INDEX.md` for relevant tags, then read `design/principles/core.md` + the layer matching the target platform (`frontend.md` / `ios.md` / `android.md`). Read only the active list — the `## Archive (deprecated)` section is ignored.
+2. Treat every `status: accepted` principle as a hard constraint. Where a `Token:` is set, use the token instead of a literal value.
+3. After producing UI, self-check against the relevant principle slugs (or delegate to `canon` for standards compliance).
+
+**At PR review the principles gate is mandatory** for any diff touching UI (`guardian` + `canon`, escalate to `judge` for high-stakes):
+- Verify the diff violates no `accepted` principle for its platform. A violation **blocks the PR** until fixed or explicitly waived by a human reviewer.
+- Note the enforcement limit honestly: quantitative principles with a `Token:` are machine-checkable; **qualitative principles are reviewer-judgment** — the gate raises them for human attention, it does not auto-prove compliance.
+- A violation that reveals a *missing* principle → file it as a new `feedback-log.md` entry (`source: review`) — the loop closes on itself.
+
+### Skill → loop-step map
+| Loop step | Primary | Support |
+|-----------|---------|---------|
+| CAPTURE | manual / `voice` (bulk import) | — |
+| ANALYZE | `voice`, `echo` | `palette`, `cast` (personas) |
+| REVIEW | human via `AskUserQuestion` | `lore` (dedup/conflict flag) |
+| PROMOTE | `muse` (tokens), `lore` (curate) | `vision` (direction), `frame` (Figma) |
+| ENFORCE | `vision`, `artisan`, `flow`, `prose`, `native` | `canon`, `palette`, `echo` |
+| GATE | `guardian`, `judge` | `canon` |
+
+> Author spawn prompts per `_common/OPUS_48_AUTHORING.md`: front-load the principle IDs to honor, give a length envelope, and state the thinking directive. ANALYZE branches run as parallel `Agent(... run_in_background: true)` spawns.

--- a/_templates/design-feedback-kit/CLAUDE.snippet.md
+++ b/_templates/design-feedback-kit/CLAUDE.snippet.md
@@ -1,0 +1,14 @@
+<!--
+Paste the block below into the target project's CLAUDE.md (or AGENTS.md).
+This is what makes principles ENFORCED: every agent loads them before UI work.
+-->
+
+## Design Principles (enforced)
+
+This project learns UI/UX feedback into durable principles under `design/`. The principles files are the source of truth.
+
+- **Before any UI/UX work** (web frontend or native iOS/Android), scan `design/principles/INDEX.md` by tag, then read `design/principles/core.md` **and** the layer for the target platform: `design/principles/frontend.md`, `design/principles/ios.md`, or `design/principles/android.md`. Treat every `status: accepted` principle as a hard constraint (ignore the `## Archive` section). Prefer the named design `Token:` over a literal value where one exists.
+- **When UI/UX feedback arrives**, run the learning loop in `design/README.md` (CAPTURE → ANALYZE → REVIEW → PROMOTE → ENFORCE). New principles require **human approval** at the REVIEW step before becoming binding — never self-promote a draft, even in AUTORUN. `/nexus` orchestrates the chain.
+- **PR review gate (mandatory for UI diffs):** verify the diff violates no accepted principle for its platform; a violation blocks merge until fixed or human-waived. Quantitative (`Token:`-backed) principles are machine-checkable; qualitative ones are reviewer judgment. If a violation reveals a *missing* rule, append it to `design/feedback-log.md` (`source: review`) so the loop captures it.
+
+Full mechanism: `design/README.md` · Agent procedure: `design/AGENT_GUIDE.md`.

--- a/_templates/design-feedback-kit/README.md
+++ b/_templates/design-feedback-kit/README.md
@@ -1,0 +1,79 @@
+# Design Feedback Learning Kit
+
+A per-project mechanism that turns **UI/UX feedback** into durable **design principles**, then enforces those principles on all future design work — for both **frontend (web)** and **native apps (iOS / Android)**.
+
+- **Source of truth:** Markdown + assets, version-controlled in the project repo (this kit, installed as `design/`).
+- **Learning mode:** semi-automated — agents *propose* principles; a human *approves* before they become binding.
+- **Platform model:** a platform-agnostic **core** layer plus per-platform layers (`frontend`, `ios`, `android`) that only hold deltas.
+
+> The principles files are the contract. Mockups are evidence. The feedback log is the audit trail of *why* each principle exists.
+
+---
+
+## The Loop
+
+```
+   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐
+   │ CAPTURE  │ → │ ANALYZE  │ → │  REVIEW  │ → │ PROMOTE  │ → │ ENFORCE  │
+   └──────────┘   └──────────┘   └──────────┘   └──────────┘   └──────────┘
+   feedback-log    Voice/Echo      human         principles/    every UI
+   (status:new)    extract draft   approve/edit  <scope>.md     task reads
+                   (status:        /reject       (status:       principles/
+                    proposed)                     accepted)      first
+```
+
+| Step | What happens | Owner | Skill(s) |
+|------|--------------|-------|----------|
+| **1. CAPTURE** | Any UI/UX feedback (interview, review, support ticket, analytics signal, usability test) is appended to `feedback-log.md` with `status: new`. | anyone | — (manual) or `voice` for bulk import |
+| **2. ANALYZE** | Cluster feedback into themes, judge emotional friction. Draft a principle **only when a theme clears the promotion threshold** (≥2 independent items, or 1 high-severity). Marks feedback `status: analyzed`, writes drafts as `status: proposed`. | agent | `voice` (sentiment/themes), `echo` (cognitive walkthrough), `palette` (usability lens) |
+| **3. REVIEW** | Human reviews each proposed principle: **Accept / Edit / Reject**. Resolves conflicts with existing principles. **Mandatory human gate — never auto-approved, even under AUTORUN.** | **human** | presented via `AskUserQuestion` |
+| **4. PROMOTE** | Accepted principle merged into the right layer (`core` / `frontend` / `ios` / `android`) with a slug ID, and indexed in `INDEX.md`. Source feedback marked `status: promoted`. Quantitative parts encoded as design tokens. | agent | `muse` (tokens), `vision` (direction), `lore` (curation/dedup) |
+| **5. ENFORCE** | Every subsequent UI task scans `INDEX.md` + reads `principles/` *before* designing/coding. **Mandatory PR gate** checks adherence and blocks violations; gaps become new feedback (loop closes). | agent | `vision`, `artisan`, `flow`, `prose`, `echo`, `palette`, `canon` (compliance), `guardian` (PR gate) |
+
+---
+
+## Directory Layout (installed as `design/` in the target project)
+
+```
+design/
+├── README.md                 # this file — the mechanism
+├── AGENT_GUIDE.md            # how agents run each loop step + enforcement rules
+├── CLAUDE.snippet.md         # paste into the project's CLAUDE.md to wire enforcement
+├── feedback-log.md           # append-only intake + learning history (audit trail)
+├── principles/
+│   ├── INDEX.md              # by-tag / by-scope index — scan this before designing
+│   ├── core.md               # platform-agnostic principles (source of truth)
+│   ├── frontend.md           # web-only deltas
+│   ├── ios.md                # iOS / HIG deltas
+│   └── android.md            # Android / Material deltas
+├── mockups/
+│   └── README.md             # naming + storage convention; principle-linked
+└── _templates/
+    ├── principle-entry.md    # schema for one principle
+    └── feedback-entry.md     # schema for one feedback item
+```
+
+---
+
+## Install into a project
+
+1. Copy this directory into the target repo as `design/`:
+   ```bash
+   cp -R _templates/design-feedback-kit <project>/design
+   ```
+2. Paste `design/CLAUDE.snippet.md` into the project's `CLAUDE.md` (or `AGENTS.md`) so every agent loads the principles before UI work.
+3. Seed `principles/core.md` with any existing conventions (or leave the examples and let the loop populate it).
+4. Run the loop whenever feedback arrives — see `AGENT_GUIDE.md`.
+
+---
+
+## Design rules for the kit itself
+
+- **One principle = one file entry**, never a vague paragraph. Each carries a slug ID, a testable statement, rationale, tags, source feedback, and Do/Don't examples.
+- **IDs are kebab-case slugs** (`P-CORE-control-feedback`, `FB-20260115-double-save`), not running numbers — so concurrent appends by different people never collide, and the ID reads as its own index entry.
+- **Core holds only what is true on every platform.** If a rule needs `if iOS` / `if web`, it belongs in a platform layer as a delta — do not duplicate.
+- **Human approval is mandatory** before a draft becomes `accepted`, in every execution mode. A single complaint is a signal, not a law — respect the promotion threshold.
+- **No two accepted principles may directly conflict.** At REVIEW, a conflicting draft is resolved by supersede, scope-narrow, or reject (see `AGENT_GUIDE.md`).
+- **Every principle traces to evidence.** No principle without at least one `feedback-log.md` source ID (exception: seeded baseline principles, marked `source: baseline`).
+- **Deprecate, don't delete.** Superseded principles move to the file's `## Archive (deprecated)` section with `Superseded by:`, preserving the rationale trail while keeping the active list (what ENFORCE reads) lean.
+- **Re-review cadence.** Quarterly, scan principles whose `Last reviewed` is >90 days old: confirm still-valid, update, or deprecate. Prevents stale rules from being enforced forever. Archive prior-year `feedback-log` entries in the same pass.

--- a/_templates/design-feedback-kit/_templates/feedback-entry.md
+++ b/_templates/design-feedback-kit/_templates/feedback-entry.md
@@ -1,0 +1,31 @@
+# Feedback Entry Template
+
+Append this block to `feedback-log.md` during the CAPTURE step (fill `status: new`, leave Analysis/Proposed blank until ANALYZE).
+
+## ID scheme (collision-free)
+`FB-<YYYYMMDD>-<slug>` — date of capture + a short kebab-case mnemonic of the feedback.
+- `FB-20260115-double-save`, `FB-20260203-tiny-tap-target`.
+- Date + slug avoids the shared-counter collision that plain `FB-NNN` causes when several people log feedback the same day.
+
+```markdown
+### FB-YYYYMMDD-<slug>
+- **Date:** YYYY-MM-DD
+- **Source:** interview | usability-test | review | support-ticket | analytics | app-store-review | echo-walkthrough
+- **Platform:** core | frontend | ios | android
+- **Raw feedback:** "<verbatim or close paraphrase — keep the user's words>"
+- **Analysis:** <ANALYZE step: theme cluster + friction assessment; blank until analyzed>
+- **Proposed principle:** <P-...-slug draft, or 'none'; blank until analyzed>
+- **Status:** new | analyzed | promoted | rejected
+- **Reviewed by:** <human, REVIEW step> · **Decision date:** YYYY-MM-DD
+<!-- if promoted: -->
+- **Promoted to:** P-<SCOPE>-<slug>
+<!-- if rejected: -->
+- **Reject reason:** <why this did not become a principle — e.g. one-off below threshold, out of scope, contradicts P-...>
+```
+
+## Rules
+- **Keep the user's words** in Raw feedback — don't pre-interpret; interpretation belongs in Analysis.
+- **Promotion threshold (guidance):** promote a theme to a principle when **≥2 independent feedback items** share it, OR a **single high-severity** item (data loss, blocked task, a11y blocker). Below that, mark `analyzed` and leave for accumulation — don't promote one-off opinions.
+- **One signal ≠ one law.** A single low-severity complaint can be `analyzed` then `rejected` with a reason; that rejection is itself useful history.
+- **Tag the platform** so ANALYZE knows whether the resulting principle is core or a delta.
+- **Archive yearly:** when `feedback-log.md` grows large, move resolved prior-year entries to `feedback-log-<YEAR>.md` to keep the active log scannable.

--- a/_templates/design-feedback-kit/_templates/principle-entry.md
+++ b/_templates/design-feedback-kit/_templates/principle-entry.md
@@ -1,0 +1,33 @@
+# Principle Entry Template
+
+Copy this block into the right layer file (`core` / `frontend` / `ios` / `android`) during the PROMOTE step.
+
+## ID scheme (collision-free + discoverable)
+Use a **kebab-case slug**, not a running number: `P-<SCOPE>-<slug>`.
+- `P-CORE-control-feedback`, `P-FE-keyboard-focus`, `P-IOS-safe-area`, `P-AND-predictive-back`.
+- Slugs never collide on concurrent appends (no shared counter) and read as their own index.
+- If a slug is already taken, the principle already exists — update it instead of adding a duplicate.
+
+```markdown
+### P-<SCOPE>-<slug> — <one-line imperative title>
+- **Statement:** <single testable rule — what must be true>
+- **Rationale:** <why this matters; the cost of violating it> [Source: <feedback IDs or standard>]
+- **Scope:** core | frontend | ios | android
+- **Tags:** <navigation | forms | a11y | feedback | motion | content | layout | error | ...>  (1-3, for INDEX.md)
+- **Source feedback:** <FB-YYYYMMDD-slug[, ...]> | baseline
+- **Do:** <concrete positive example>
+- **Don't:** <concrete anti-example>
+- **Token:** <design-token name if the quantitative part is encoded via muse, else —>
+- **Status:** proposed | accepted | deprecated
+- **Added:** YYYY-MM-DD · **Last reviewed:** YYYY-MM-DD
+<!-- if deprecated: move the entry under the file's `## Archive (deprecated)` section and add: -->
+- **Superseded by:** P-<SCOPE>-<slug>
+```
+
+## Rules
+- **Statement must be testable.** A reviewer (human or `canon`) can decide pass/fail on a real screen.
+- **Core vs platform:** put it in `core` only if true on every platform; otherwise it is a platform delta. A platform delta must not contradict an accepted `core` principle.
+- **No principle without evidence:** `Source feedback` is required (use `baseline` only for seeded defaults).
+- **Tags are mandatory** — they drive `INDEX.md` discoverability once principles grow past a handful.
+- **Deprecate, don't delete:** move superseded entries to the file's `## Archive (deprecated)` section so the active list (what ENFORCE reads) stays lean.
+- **Link mockups** that demonstrate the rule via `mockups/` filenames in Do/Don't where helpful.

--- a/_templates/design-feedback-kit/feedback-log.md
+++ b/_templates/design-feedback-kit/feedback-log.md
@@ -1,0 +1,25 @@
+# Feedback Log (append-only)
+
+The audit trail of every UI/UX feedback item and what became of it. **Never edit history; only append and update `status`/`promoted-to`.** Each entry follows `_templates/feedback-entry.md`.
+
+> Status flow: `new` → `analyzed` → (`promoted` | `rejected`). A `promoted` entry links to the principle slug it produced.
+> ID format: `FB-YYYYMMDD-<slug>` (date + short mnemonic — collision-free on concurrent appends).
+> Promotion threshold: ≥2 independent items on a theme, OR a single high-severity item (data loss / blocked task / a11y blocker).
+> Archive: move resolved prior-year entries to `feedback-log-<YEAR>.md` when this file grows large.
+
+---
+
+### FB-20260115-double-save (example)
+- **Date:** 2026-01-15
+- **Source:** usability-test
+- **Platform:** frontend
+- **Raw feedback:** "I tapped Save twice because nothing happened — then it saved twice."
+- **Analysis:** Missing in-flight feedback on submit; double-submission risk. Theme: responsiveness. (Echo friction: high — uncertainty + duplicate side effect.) High-severity (duplicate write) → meets threshold on its own.
+- **Proposed principle:** P-CORE-control-feedback (feedback within 100ms + disable while pending).
+- **Status:** promoted
+- **Reviewed by:** (human) · **Decision date:** 2026-01-16
+- **Promoted to:** P-CORE-control-feedback
+
+---
+
+<!-- New feedback is appended below by the CAPTURE step with status: new. -->

--- a/_templates/design-feedback-kit/mockups/README.md
+++ b/_templates/design-feedback-kit/mockups/README.md
@@ -1,0 +1,24 @@
+# Mockups
+
+Visual evidence and reference designs that demonstrate principles. Mockups are **supporting artifacts**, not the source of truth — the principles files are. Store accepted reference designs and Do/Don't comparisons here.
+
+## What to store
+- **Reference mockups** for an accepted principle (the "Do" made concrete).
+- **Before/After pairs** when a principle was created from feedback (shows the fix).
+- Static images (`.png`/`.svg`), self-contained HTML prototypes (from `forge`), or Figma export links in a `.md` sidecar.
+
+## Naming convention
+```
+mockups/
+  P-CORE-control-feedback__do.png
+  P-CORE-control-feedback__dont.png
+  P-FE-responsive-320__do.png
+  FB-20260115-double-save__before.png
+  FB-20260115-double-save__after.png
+```
+- Prefix with the **principle slug** (`P-<scope>-<slug>`) or **feedback ID** (`FB-YYYYMMDD-<slug>`) it belongs to so links never rot.
+- Use `__do` / `__dont` / `__before` / `__after` suffixes for comparisons.
+- For Figma sources, add `P-<scope>-<slug>__name.md` with the file URL + node id (bridge via `frame` / Figma MCP).
+
+## Linking
+Reference mockups from principle entries (in `principles/*.md`) and from feedback entries by filename, e.g. `Do: see mockups/P-CORE-control-feedback__do.png`.

--- a/_templates/design-feedback-kit/principles/INDEX.md
+++ b/_templates/design-feedback-kit/principles/INDEX.md
@@ -1,0 +1,28 @@
+# Principles Index
+
+Discoverability layer over `core.md` / `frontend.md` / `ios.md` / `android.md`. **Before designing, scan this to find existing principles by topic** instead of reading every file. Regenerate (or append) during the PROMOTE step — keep it in sync with the layer files.
+
+> Maintenance: the PROMOTE step adds the new principle's row here. A periodic review (see `../README.md` → "Re-review cadence") prunes deprecated rows.
+
+## By tag
+
+| Tag | Principles |
+|-----|-----------|
+| feedback | P-CORE-control-feedback, P-CORE-reversible-destructive |
+| responsiveness | P-CORE-control-feedback |
+| error | P-CORE-error-cause-action, P-CORE-reversible-destructive |
+| content | P-CORE-error-cause-action |
+| a11y | P-FE-keyboard-focus, P-FE-responsive-320, P-IOS-safe-area |
+| navigation | P-FE-keyboard-focus, P-IOS-native-nav, P-AND-predictive-back |
+| layout | P-FE-responsive-320, P-IOS-safe-area, P-AND-edge-to-edge |
+| motion | — |
+| forms | — |
+
+## By scope
+
+| Scope | Principles (accepted) |
+|-------|-----------------------|
+| core | P-CORE-control-feedback, P-CORE-error-cause-action, P-CORE-reversible-destructive |
+| frontend | P-FE-keyboard-focus, P-FE-responsive-320 |
+| ios | P-IOS-safe-area, P-IOS-native-nav |
+| android | P-AND-predictive-back, P-AND-edge-to-edge |

--- a/_templates/design-feedback-kit/principles/android.md
+++ b/_templates/design-feedback-kit/principles/android.md
@@ -1,0 +1,35 @@
+# Android Principles — deltas only
+
+Android-specific rules layered on top of `core.md`, aligned with Material Design (Material 3 / M3 Expressive). Add here only platform-specific rules (back navigation, system bars, Material idioms, predictive back). Schema: `_templates/principle-entry.md`. ID prefix: `P-AND-<slug>`.
+
+---
+
+### P-AND-predictive-back — Honor system back and predictive back
+- **Statement:** The system back gesture/button always works and supports predictive-back animation; never trap the user.
+- **Rationale:** Core Android navigation contract; Android 14+ predictive back. [Source: baseline — Material 3]
+- **Scope:** android
+- **Tags:** navigation
+- **Source feedback:** baseline
+- **Do:** `OnBackPressedDispatcher` / predictive-back APIs, Compose `BackHandler`.
+- **Don't:** intercept back to block exit without reason.
+- **Token:** —
+- **Status:** accepted · **Added:** 2026-01-01 · **Last reviewed:** 2026-01-01
+
+### P-AND-edge-to-edge — Edge-to-edge with inset-aware layouts
+- **Statement:** Draw edge-to-edge and apply window insets so content is never hidden behind system bars or the navigation area.
+- **Rationale:** targetSdk 35+ edge-to-edge default; Material guidance. [Source: baseline]
+- **Scope:** android
+- **Tags:** layout
+- **Source feedback:** baseline
+- **Do:** `WindowInsets`, `Modifier.safeDrawingPadding()`.
+- **Don't:** assume opaque system bars.
+- **Token:** —
+- **Status:** accepted · **Added:** 2026-01-01 · **Last reviewed:** 2026-01-01
+
+---
+
+<!-- PROMOTE step appends new Android-specific principles above this line. -->
+
+## Archive (deprecated)
+
+<!-- Superseded principles move here. ENFORCE ignores this section. -->

--- a/_templates/design-feedback-kit/principles/core.md
+++ b/_templates/design-feedback-kit/principles/core.md
@@ -1,0 +1,48 @@
+# Core Design Principles (platform-agnostic)
+
+Binding for **all** surfaces (web, iOS, Android). Platform layers (`frontend.md`, `ios.md`, `android.md`) may add deltas but must not contradict these. Each entry follows `_templates/principle-entry.md`. IDs are slugs (`P-CORE-<slug>`), not numbers — see `INDEX.md` for the cross-layer index.
+
+> Status legend: `proposed` (awaiting human review — NOT yet binding) · `accepted` (binding) · `deprecated` (moved to Archive below).
+
+---
+
+### P-CORE-control-feedback — Every interactive control gives feedback within 100ms
+- **Statement:** Any tap/click/keypress on an interactive element must produce a visible state change (press, loading, or result) within 100ms.
+- **Rationale:** Perceived responsiveness; silence reads as "broken". [Source: baseline — Nielsen response-time limits]
+- **Scope:** core
+- **Tags:** feedback, responsiveness
+- **Source feedback:** baseline
+- **Do:** show a pressed state + inline spinner on submit; disable the control while pending.
+- **Don't:** block the UI with no indicator while a request is in flight.
+- **Token:** —
+- **Status:** accepted · **Added:** 2026-01-01 · **Last reviewed:** 2026-01-01
+
+### P-CORE-error-cause-action — Errors state the cause and the next action
+- **Statement:** Error messages name what went wrong in plain language and offer a concrete recovery action.
+- **Rationale:** Generic errors ("Something went wrong") strand users. [Source: baseline]
+- **Scope:** core
+- **Tags:** error, content
+- **Source feedback:** baseline
+- **Do:** "Card declined — try another payment method." + retry button.
+- **Don't:** "Error 500" with no guidance.
+- **Token:** —
+- **Status:** accepted · **Added:** 2026-01-01 · **Last reviewed:** 2026-01-01
+
+### P-CORE-reversible-destructive — Destructive actions are reversible or confirmed
+- **Statement:** Any action that destroys user data offers undo, or requires explicit confirmation when undo is impossible.
+- **Rationale:** Protects against accidental loss; trust. [Source: baseline]
+- **Scope:** core
+- **Tags:** error, feedback
+- **Source feedback:** baseline
+- **Do:** delete → toast with "Undo" for 5s; permanent delete → typed confirmation.
+- **Don't:** immediate irreversible delete on a single tap.
+- **Token:** —
+- **Status:** accepted · **Added:** 2026-01-01 · **Last reviewed:** 2026-01-01
+
+---
+
+<!-- New accepted principles are appended above this line by the PROMOTE step. -->
+
+## Archive (deprecated)
+
+<!-- Superseded principles move here (keep full entry + `Superseded by:`). ENFORCE ignores this section. -->

--- a/_templates/design-feedback-kit/principles/frontend.md
+++ b/_templates/design-feedback-kit/principles/frontend.md
@@ -1,0 +1,35 @@
+# Frontend (Web) Principles — deltas only
+
+Web-specific rules layered on top of `core.md`. Add an entry here only when the rule is web-specific (responsive, pointer+keyboard, browser, SEO/a11y semantics). Shared rules belong in `core.md`. Schema: `_templates/principle-entry.md`. ID prefix: `P-FE-<slug>`.
+
+---
+
+### P-FE-keyboard-focus — Fully keyboard-operable, visible focus
+- **Statement:** Every interactive element is reachable and operable by keyboard with a visible focus ring (never `outline: none` without a replacement).
+- **Rationale:** WCAG 2.4.7 / keyboard users; web's primary a11y vector. [Source: baseline — WCAG 2.2]
+- **Scope:** frontend
+- **Tags:** a11y, navigation
+- **Source feedback:** baseline
+- **Do:** custom `:focus-visible` style with ≥3:1 contrast.
+- **Don't:** remove focus outlines for aesthetics.
+- **Token:** —
+- **Status:** accepted · **Added:** 2026-01-01 · **Last reviewed:** 2026-01-01
+
+### P-FE-responsive-320 — Layout holds from 320px to wide desktop
+- **Statement:** No horizontal scroll or clipped content at 320px; touch targets ≥44×44px on coarse pointers.
+- **Rationale:** Mobile-web majority; responsive contract. [Source: baseline]
+- **Scope:** frontend
+- **Tags:** layout, a11y
+- **Source feedback:** baseline
+- **Do:** fluid layouts, container queries, `min()`/`clamp()`.
+- **Don't:** fixed pixel widths that overflow narrow viewports.
+- **Token:** —
+- **Status:** accepted · **Added:** 2026-01-01 · **Last reviewed:** 2026-01-01
+
+---
+
+<!-- PROMOTE step appends new web-specific principles above this line. -->
+
+## Archive (deprecated)
+
+<!-- Superseded principles move here. ENFORCE ignores this section. -->

--- a/_templates/design-feedback-kit/principles/ios.md
+++ b/_templates/design-feedback-kit/principles/ios.md
@@ -1,0 +1,35 @@
+# iOS Principles — deltas only
+
+iOS-specific rules layered on top of `core.md`, aligned with Apple Human Interface Guidelines (HIG). Add here only platform-specific rules (gestures, system integration, HIG idioms, Liquid Glass / iOS 26 conventions). Schema: `_templates/principle-entry.md`. ID prefix: `P-IOS-<slug>`.
+
+---
+
+### P-IOS-safe-area — Respect safe areas and Dynamic Type
+- **Statement:** Layouts honor safe-area insets and scale with Dynamic Type up to the largest accessibility sizes without truncation or overlap.
+- **Rationale:** HIG; notch/Home-indicator and accessibility text scaling. [Source: baseline — Apple HIG]
+- **Scope:** ios
+- **Tags:** layout, a11y
+- **Source feedback:** baseline
+- **Do:** SwiftUI `.safeAreaInset`, scalable fonts, `ViewThatFits` for large text.
+- **Don't:** hardcode point sizes that clip at AX5.
+- **Token:** —
+- **Status:** accepted · **Added:** 2026-01-01 · **Last reviewed:** 2026-01-01
+
+### P-IOS-native-nav — Use platform-native navigation and gestures
+- **Statement:** Honor the system back-swipe, standard navigation stacks, and native controls before introducing custom alternatives.
+- **Rationale:** Muscle memory; HIG consistency. [Source: baseline]
+- **Scope:** ios
+- **Tags:** navigation
+- **Source feedback:** baseline
+- **Do:** `NavigationStack`, sheets, edge-swipe back.
+- **Don't:** custom back buttons that break interactive pop.
+- **Token:** —
+- **Status:** accepted · **Added:** 2026-01-01 · **Last reviewed:** 2026-01-01
+
+---
+
+<!-- PROMOTE step appends new iOS-specific principles above this line. -->
+
+## Archive (deprecated)
+
+<!-- Superseded principles move here. ENFORCE ignores this section. -->


### PR DESCRIPTION
## Summary
Adds a per-project, reusable kit that turns UI/UX feedback into durable design principles for frontend (web) and native apps (iOS/Android), enforced on future design work.

The mechanism is a 5-stage loop — **CAPTURE → ANALYZE → REVIEW → PROMOTE → ENFORCE** — with Markdown as the source of truth, semi-automated learning (human-approved promotion), and a platform-agnostic core + per-platform delta layers.

## Changes
- `design-feedback-kit/README.md` — mechanism, loop, install steps, kit rules
- `principles/{core,frontend,ios,android}.md` — seeded principle layers (core + deltas)
- `principles/INDEX.md` — by-tag / by-scope discoverability index
- `feedback-log.md` — append-only audit trail of feedback → principle
- `_templates/{principle,feedback}-entry.md` — entry schemas
- `mockups/README.md` — ID-linked naming convention
- `AGENT_GUIDE.md` — per-loop-step agent procedure + enforcement
- `CLAUDE.snippet.md` — paste-in snippet wiring enforcement into a project

## Design decisions (post-review hardening)
- Slug-based collision-free IDs (`P-CORE-control-feedback`, `FB-20260115-double-save`)
- Deprecated principles archived (kept out of the ENFORCE read path)
- Promotion threshold (≥2 independent items or 1 high-severity)
- Conflict resolution (supersede / scope-narrow / reject)
- Mandatory human REVIEW gate (never auto-approved, even under AUTORUN)
- Mandatory PR principles gate; quarterly re-review cadence

## Testing
- [x] Docs/templates only — no executable code
- [x] No stale ID/format references (grep verified)
- [x] Conventional Commits compliant

## Notes
Lives under `_templates/` as a copy-into-`design/` kit. No runtime impact on the skills repo.