### PR TITLE
feat(templates): add learning-loop-kit base template

### DIFF
--- a/_templates/learning-loop-kit/INSTANCES.md
+++ b/_templates/learning-loop-kit/INSTANCES.md
@@ -1,0 +1,26 @@
+# Learning-Loop Kit — Instance Registry
+
+Tracks every kit instantiated from this base. One row per instance.
+
+## Rendered (shipped)
+
+| # | Kit | Slug | Signal → Rule | Config | Status |
+|---|-----|------|---------------|--------|--------|
+| 1 | Design Feedback | `design-feedback` | UI/UX feedback → design principles (core + frontend/ios/android) | `instances/design-feedback.config.md` | **shipped — predecessor / non-strict render** (`_templates/design-feedback-kit/`; uses `Scope:`/`Token:` instead of base `Layer:`/`Check:` — see config) |
+
+## Proposed (candidate domains — not yet rendered)
+
+Ranked by fit with the loop pattern. Render on demand via `README.md` → "Instantiate".
+
+| Kit | Slug | Signal → Rule | ANALYZE / ENFORCE / GATE skills | Machine encoding | Fit |
+|-----|------|---------------|----------------------------------|------------------|-----|
+| Review Knowledge | `review-knowledge` | PR review comments → coding conventions | judge, zen / artisan, builder / guardian, judge | lint rule (Semgrep/ESLint) | ★★★ |
+| Incident Learning | `incident-learning` | incidents / postmortems → reliability rules + runbook | beacon, triage, omen / beacon, builder / guardian, beacon | alert rule + SLO | ★★★ |
+| Secure-Coding Rules | `secure-coding` | vuln / CVE / audit findings → banned patterns + secure-impl rules | sentinel, chain, vigil / sentinel, builder / guardian, sentinel | lint rule (Semgrep) | ★★★ |
+| Voice & Tone | `voice-tone` | copy feedback → UX-writing / brand-voice rules | prose, canon, tone / prose, artisan / guardian, canon | none (reviewer judgment) | ★★★ |
+| AI-Eval | `ai-eval` | LLM-output feedback → prompt rules + eval rubric + regression cases | oracle / oracle, builder / guardian, oracle | eval harness (regression set) | ★★☆ |
+| API Convention | `api-convention` | API review feedback → naming/versioning/error-shape rules | gateway / gateway, builder / guardian, gateway | OpenAPI lint (spectral) | ★★☆ |
+| Architecture Decision | `arch-decision` | design decisions → architectural constraints | atlas, stratum / atlas, builder / guardian, atlas | fitness function / dep-cruiser | ★★☆ |
+| Test Strategy | `test-strategy` | flaky / recurring failures → testing principles + quarantine rules | radar, vista / radar / guardian, radar | quarantine list + CI rule | ★☆☆ |
+
+> Adding a row to "Proposed" is cheap — it just records intent. Rendering is the work; do it when a real signal stream for that domain exists (don't render speculative kits with no signals to feed them — they become dead docs).

--- a/_templates/learning-loop-kit/README.md
+++ b/_templates/learning-loop-kit/README.md
@@ -1,0 +1,91 @@
+# Learning-Loop Kit (base template)
+
+A parameterized base for **repo-local learning loops**: mechanisms that turn a recurring stream of signals (feedback, review comments, incidents, findings…) into durable, versioned **rules** that agents enforce on all future work.
+
+`design-feedback-kit` is **instance #1** of this base. This template generalizes its machinery so any domain with the same loop shape can be instantiated in minutes.
+
+> The loop machinery is generic. Only the **domain knobs** differ — see `kit.config.template.md`.
+
+---
+
+## The loop (identical across all instances)
+
+```
+CAPTURE → ANALYZE → REVIEW → PROMOTE → ENFORCE
+```
+
+| Step | Generic behavior | Knob that varies it |
+|------|------------------|---------------------|
+| **CAPTURE** | Append a `{{SIGNAL_NOUN}}` to `{{SIGNAL_LOG}}` (`status: new`). | `SIGNAL_NOUN`, `SIGNAL_PREFIX`, `SIGNAL_SOURCES` |
+| **ANALYZE** | Cluster signals into themes; draft a `{{RULE_NOUN}}` when the **promotion threshold** is met. | `ANALYZE_SKILLS`, `PROMOTION_THRESHOLD` |
+| **REVIEW** | **Mandatory human gate** — Accept / Edit / Reject. Never auto-approved, even under AUTORUN. | (always human) |
+| **PROMOTE** | Merge accepted rule into the right layer with a slug ID; index it; encode machine-checkable parts. | `RULE_PREFIX`, `LAYERS`, `MACHINE_ENCODING`, `PROMOTE_SKILLS` |
+| **ENFORCE** | Every future task reads the rules first; PR gate blocks violations; gaps become new signals. | `ENFORCE_SKILLS`, `GATE_SKILLS` |
+
+Shared invariants (do not change per instance): slug-based collision-free IDs, evidence-traceable rules, deprecate-don't-delete (Archive section), `INDEX.md` discoverability, quarterly re-review cadence.
+
+---
+
+## Knobs (the only things that vary)
+
+Filled per instance in a `*.config.md` (template: `kit.config.template.md`). Summary:
+
+| Knob | Meaning | design-feedback value |
+|------|---------|------------------------|
+| `KIT_NAME` / `KIT_SLUG` | human + dir name | Design Feedback / `design-feedback` |
+| `DOMAIN_DIR` | where it installs in a project | `design` |
+| `RULE_NOUN(_PLURAL)` | what a rule is called | principle / principles |
+| `RULE_PREFIX` | slug prefix for rules | `P` (→ `P-CORE-control-feedback`) |
+| `SIGNAL_NOUN(_PLURAL)` | what an input is called | feedback |
+| `SIGNAL_PREFIX` | slug prefix for signals | `FB` (→ `FB-20260115-double-save`) |
+| `SIGNAL_LOG` | the audit-trail filename | `feedback-log.md` |
+| `LAYERS` | rule partitioning (or `core` only for flat) | core, frontend, ios, android |
+| `SIGNAL_SOURCES` | allowed `Source:` values | interview, usability-test, review, … |
+| `ANALYZE_SKILLS` | extraction specialists | voice, echo, palette |
+| `PROMOTE_SKILLS` | curation / encoding | muse, vision, lore |
+| `ENFORCE_SKILLS` | who reads rules before acting | vision, artisan, flow, prose, native |
+| `GATE_SKILLS` | PR gate | guardian, canon, judge |
+| `PROMOTION_THRESHOLD` | when a theme becomes a rule | ≥2 independent OR 1 high-severity |
+| `MACHINE_ENCODING` | how quantitative rules are auto-checked | design tokens via muse |
+| `ARTIFACT_NOUN` / `ARTIFACT_DIR` | evidence assets | mockup / mockups |
+
+---
+
+## Instantiate a new kit
+
+Rendering is **part scriptable, part human judgment**. Scalar tokens substitute cleanly; list tokens do not (see step 3).
+
+1. **Config** — copy and fill the knobs:
+   ```bash
+   cp _templates/learning-loop-kit/kit.config.template.md \
+      _templates/learning-loop-kit/instances/<kit-slug>.config.md
+   ```
+2. **Copy the base:**
+   ```bash
+   cp -R _templates/learning-loop-kit/base _templates/<kit-slug>-kit
+   ```
+3. **Substitute tokens:**
+   - **Scalar tokens** (`KIT_NAME`, `DOMAIN_DIR`, `RULE_NOUN(_PLURAL)`, `RULE_PREFIX`, `SIGNAL_NOUN(_PLURAL)`, `SIGNAL_PREFIX`, `SIGNAL_LOG`, `ARTIFACT_NOUN`, `ARTIFACT_DIR`, `MACHINE_ENCODING`, `PROMOTION_THRESHOLD`, `REVIEW_CADENCE`) — safe to `sed -i 's/{{KIT_NAME}}/.../g'` across the kit.
+   - **List tokens** (`LAYERS`, `SIGNAL_SOURCES`, `ANALYZE_SKILLS`, `PROMOTE_SKILLS`, `ENFORCE_SKILLS`, `GATE_SKILLS`) — **substitute by hand.** They render differently per context (prose "one of …", table rows, comma lists), so blind `sed` produces wrong output. Read each occurrence and expand it appropriately.
+4. **Structure fixups:**
+   - `mv base.../signals-log.md → <SIGNAL_LOG>` (the filename from your config).
+   - `mv artifacts/ → <ARTIFACT_DIR>/`, or delete it entirely if `ARTIFACT_NOUN: none`.
+   - For **each delta layer** in `LAYERS` beyond `core`, copy `rules/core.md` → `rules/<layer>.md`, change its title/prefix to that layer, and clear the core seed entries. Add a by-layer row in `rules/INDEX.md`.
+   - Replace the `core.md` seed skeleton with 1-3 real baseline rules (or delete it to start empty).
+5. **Verify (render gate):**
+   ```bash
+   _templates/learning-loop-kit/_scripts/check-rendered.sh _templates/<kit-slug>-kit
+   ```
+   Must print `✓ … clean`. It fails on leftover `{{TOKEN}}`, `YYYY-MM-DD`, or `<slug>`/`<LAYER>` markers outside `_templates/`.
+6. **Register** in `INSTANCES.md`.
+7. **Install** into a project: `cp -R _templates/<kit-slug>-kit <project>/<DOMAIN_DIR>` and paste its `CLAUDE.snippet.md` into the project's `CLAUDE.md`.
+
+> `design-feedback-kit` is a worked example of the *rendered shape* — but it is a **predecessor / non-strict render** (uses `Scope:`/`Token:` where the base uses `Layer:`/`Check:`). See `instances/design-feedback.config.md`.
+
+---
+
+## When this pattern fits (and when it doesn't)
+
+**Fits** when ALL hold: (a) signals arrive over time, not once; (b) they should crystallize into reusable rules; (c) future work can be checked against those rules; (d) a human should approve rules (a signal ≠ a law); (e) you want an audit trail of *why* each rule exists.
+
+**Doesn't fit:** one-off decisions (use an ADR/doc), purely mechanical config (use lint/CI directly), or rules with no enforcement surface (nobody reads them → dead docs). Candidate domains: see `INSTANCES.md`.

--- a/_templates/learning-loop-kit/_scripts/check-rendered.sh
+++ b/_templates/learning-loop-kit/_scripts/check-rendered.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# check-rendered.sh — verify a rendered Learning-Loop Kit has no leftover template residue.
+# Usage: check-rendered.sh <kit-dir>
+# Exit 0 = clean; exit 1 = residue found (prints offending file:line).
+#
+# Run this after rendering base/ into a new <slug>-kit and substituting tokens.
+# It is the render gate: a kit must pass before it is committed or installed.
+set -euo pipefail
+
+DIR="${1:?usage: check-rendered.sh <kit-dir>}"
+[ -d "$DIR" ] || { echo "not a directory: $DIR" >&2; exit 2; }
+
+fail=0
+
+# 1. Unrendered {{TOKEN}} placeholders.
+if grep -rnE '\{\{[A-Z_]+\}\}' "$DIR"; then
+  echo "✗ unrendered {{TOKEN}} placeholders above — substitute them." >&2
+  fail=1
+fi
+
+# 2. Leftover date placeholders in seeded entries (skeleton not replaced).
+#    _templates/ is exempt — entry templates legitimately keep date/slug placeholders.
+if grep -rn --exclude-dir='_templates' 'YYYY-MM-DD\|YYYYMMDD-<slug>' "$DIR"; then
+  echo "✗ leftover date placeholders above — replace with real dates/IDs in seeded entries." >&2
+  fail=1
+fi
+
+# 3. Leftover angle-bracket skeleton markers in non-template files.
+if grep -rn --include='*.md' --exclude-dir='_templates' '<slug>\|<LAYER>\|<kit-slug>' "$DIR"; then
+  echo "✗ leftover skeleton markers above (outside _templates/) — fill in concrete values." >&2
+  fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "✓ $DIR is clean — no template residue."
+fi
+exit "$fail"

--- a/_templates/learning-loop-kit/base/AGENT_GUIDE.md
+++ b/_templates/learning-loop-kit/base/AGENT_GUIDE.md
@@ -1,0 +1,46 @@
+# Agent Guide — {{KIT_NAME}} Kit
+
+Two responsibilities: (A) **run the learning loop** when a {{SIGNAL_NOUN}} arrives, and (B) **enforce** accepted {{RULE_NOUN_PLURAL}} on every domain task. Orchestrate via `/nexus` or run steps directly.
+
+## A. Running the loop
+
+### Step 2 — ANALYZE
+Spawn {{ANALYZE_SKILLS}} (parallel where independent), then synthesize.
+- **Promotion threshold** — only draft a {{RULE_NOUN}} when: {{PROMOTION_THRESHOLD}}. Below threshold → mark the {{SIGNAL_NOUN}} `analyzed` and leave to accumulate.
+- For themes that clear it, write a draft using `_templates/rule-entry.md` (`status: proposed`). Decide layer: universal across `{{LAYERS}}` → `core`; else the matching delta layer (must not duplicate/contradict a core rule).
+- Scan `rules/INDEX.md` by tag first — if a matching {{RULE_NOUN}} exists, propose an **edit** instead of a new entry. Mark the source {{SIGNAL_NOUN}} `analyzed` and link the draft.
+
+### Step 3 — REVIEW (human gate — mandatory, never auto-approved)
+**Never skipped — not even under `/nexus` AUTORUN / AUTORUN_FULL.** No agent self-promotes a draft to `accepted`. Present each via `AskUserQuestion`: Statement, source {{SIGNAL_NOUN}} IDs, layer → **[Accept] [Edit] [Reject]**.
+- Accept → `status: accepted`, go to PROMOTE. Edit → revise, re-present. Reject → mark source `rejected` + reason.
+- **Conflict resolution** — if a draft contradicts an accepted {{RULE_NOUN}}: (a) **supersede** (deprecate old → Archive, set `Superseded by:`), (b) **scope-narrow** (restrict one to a layer/context), or (c) **reject**. Never leave two accepted {{RULE_NOUN_PLURAL}} in direct conflict. {{PROMOTE_SKILLS}} may pre-flag conflicts/dupes.
+
+### Step 4 — PROMOTE
+- Append the accepted entry to the right `rules/*.md` with a slug ID (`{{RULE_PREFIX}}-<LAYER>-<slug>`) — no shared counter, no collisions.
+- Add its row to `rules/INDEX.md` (by-tag + by-layer).
+- Mark source {{SIGNAL_NOUN}} `promoted` + `Promoted to: {{RULE_PREFIX}}-<LAYER>-<slug>`.
+- If the {{RULE_NOUN}} has a machine-checkable part, encode it via **{{MACHINE_ENCODING}}** and record the reference in the entry's `Check:` field.
+- Add a reference {{ARTIFACT_NOUN}} to `{{ARTIFACT_DIR}}/` (Do, + Before/After) when applicable.
+
+## B. Enforcement (every domain task)
+
+**Before** any work in this domain, an agent MUST:
+1. Scan `rules/INDEX.md` by relevant tags, then read `rules/core.md` + the matching layer file. Active list only — `## Archive` is ignored.
+2. Treat every `accepted` {{RULE_NOUN}} as a hard constraint. Where a `Check:` is set, satisfy/run it.
+3. Self-check the output against the relevant slugs (or delegate to a {{GATE_SKILLS}} agent).
+
+**At PR review the {{RULE_NOUN}} gate is mandatory** ({{GATE_SKILLS}}):
+- Verify the diff violates no `accepted` {{RULE_NOUN}}. A violation **blocks** until fixed or human-waived.
+- Honesty note: `Check:`-backed rules are machine-verifiable; the rest are reviewer judgment — the gate raises them for attention, it doesn't auto-prove compliance.
+- A violation revealing a *missing* rule → file a new `{{SIGNAL_LOG}}` entry (`source: review`). The loop closes on itself.
+
+### Skill → loop-step map
+| Step | Skills |
+|------|--------|
+| ANALYZE | {{ANALYZE_SKILLS}} |
+| REVIEW | human via `AskUserQuestion` (+ {{PROMOTE_SKILLS}} for conflict flags) |
+| PROMOTE | {{PROMOTE_SKILLS}} |
+| ENFORCE | {{ENFORCE_SKILLS}} |
+| GATE | {{GATE_SKILLS}} |
+
+> Author spawn prompts per `_common/OPUS_48_AUTHORING.md`: front-load the {{RULE_NOUN}} slugs to honor, set a length envelope, state the thinking directive. Run independent ANALYZE branches as parallel background spawns.

--- a/_templates/learning-loop-kit/base/CLAUDE.snippet.md
+++ b/_templates/learning-loop-kit/base/CLAUDE.snippet.md
@@ -1,0 +1,14 @@
+<!--
+Paste the block below into the target project's CLAUDE.md (or AGENTS.md).
+This is what makes {{RULE_NOUN_PLURAL}} ENFORCED: every agent loads them before domain work.
+-->
+
+## {{KIT_NAME}} {{RULE_NOUN_PLURAL}} (enforced)
+
+This project learns {{SIGNAL_NOUN_PLURAL}} into durable {{RULE_NOUN_PLURAL}} under `{{DOMAIN_DIR}}/`. The {{RULE_NOUN}} files are the source of truth.
+
+- **Before any {{DOMAIN_DIR}} work**, scan `{{DOMAIN_DIR}}/rules/INDEX.md` by tag, then read `{{DOMAIN_DIR}}/rules/core.md` + the matching layer file. Treat every `accepted` {{RULE_NOUN}} as a hard constraint (ignore the `## Archive` section). Where a `Check:` is set, satisfy it.
+- **When a {{SIGNAL_NOUN}} arrives**, run the loop in `{{DOMAIN_DIR}}/README.md` (CAPTURE → ANALYZE → REVIEW → PROMOTE → ENFORCE). New {{RULE_NOUN_PLURAL}} require **human approval** at REVIEW before binding — never self-promote, even in AUTORUN. `/nexus` orchestrates the chain.
+- **PR review gate (mandatory):** verify the diff violates no accepted {{RULE_NOUN}}; a violation blocks merge until fixed or human-waived. `Check:`-backed rules are machine-verifiable; the rest are reviewer judgment. A violation revealing a missing rule → append to `{{DOMAIN_DIR}}/{{SIGNAL_LOG}}` (`source: review`).
+
+Full mechanism: `{{DOMAIN_DIR}}/README.md` · Agent procedure: `{{DOMAIN_DIR}}/AGENT_GUIDE.md`.

--- a/_templates/learning-loop-kit/base/README.md
+++ b/_templates/learning-loop-kit/base/README.md
@@ -1,0 +1,66 @@
+# {{KIT_NAME}} Kit
+
+A per-project mechanism that turns **{{SIGNAL_NOUN_PLURAL}}** into durable **{{RULE_NOUN_PLURAL}}**, then enforces them on all future work in this domain.
+
+- **Source of truth:** Markdown + assets, version-controlled in the repo (installed as `{{DOMAIN_DIR}}/`).
+- **Learning mode:** semi-automated — agents *propose* {{RULE_NOUN_PLURAL}}; a human *approves* before they bind.
+- **Structure:** layers = `{{LAYERS}}` (core = universal; others = deltas).
+
+> The {{RULE_NOUN}} files are the contract. {{ARTIFACT_NOUN}}s are evidence. `{{SIGNAL_LOG}}` is the audit trail of *why* each {{RULE_NOUN}} exists.
+
+Generated from `_templates/learning-loop-kit` (base). Config: `<kit-slug>.config.md`.
+
+---
+
+## The Loop
+
+```
+CAPTURE → ANALYZE → REVIEW → PROMOTE → ENFORCE
+```
+
+| Step | What happens | Owner | Skill(s) |
+|------|--------------|-------|----------|
+| **1. CAPTURE** | A {{SIGNAL_NOUN}} is appended to `{{SIGNAL_LOG}}` (`status: new`). | anyone | manual / bulk import |
+| **2. ANALYZE** | Cluster into themes; draft a {{RULE_NOUN}} only when the threshold ({{PROMOTION_THRESHOLD}}) is met. | agent | {{ANALYZE_SKILLS}} |
+| **3. REVIEW** | Human: **Accept / Edit / Reject**. Resolves conflicts. **Mandatory — never auto-approved, even under AUTORUN.** | **human** | `AskUserQuestion` |
+| **4. PROMOTE** | Merge accepted {{RULE_NOUN}} into the right layer (slug ID), index it, encode machine-checkable parts ({{MACHINE_ENCODING}}). | agent | {{PROMOTE_SKILLS}} |
+| **5. ENFORCE** | Every future task scans `INDEX.md` + reads rules first. **Mandatory PR gate** blocks violations; gaps become new {{SIGNAL_NOUN_PLURAL}}. | agent | {{ENFORCE_SKILLS}} / gate: {{GATE_SKILLS}} |
+
+---
+
+## Directory Layout (installed as `{{DOMAIN_DIR}}/`)
+
+```
+{{DOMAIN_DIR}}/
+├── README.md                 # this mechanism
+├── AGENT_GUIDE.md            # per-step agent procedure + enforcement
+├── CLAUDE.snippet.md         # paste into the project's CLAUDE.md
+├── {{SIGNAL_LOG}}            # append-only audit trail
+├── rules/
+│   ├── INDEX.md              # by-tag / by-layer index — scan before working
+│   ├── core.md               # universal {{RULE_NOUN_PLURAL}}
+│   └── <layer>.md            # one per delta layer in {{LAYERS}}
+├── {{ARTIFACT_DIR}}/         # ID-linked evidence (omit if none)
+└── _templates/
+    ├── rule-entry.md
+    └── signal-entry.md
+```
+
+---
+
+## Install into a project
+
+1. `cp -R <this kit> <project>/{{DOMAIN_DIR}}`
+2. Paste `{{DOMAIN_DIR}}/CLAUDE.snippet.md` into the project's `CLAUDE.md` / `AGENTS.md`.
+3. Seed `rules/core.md` with existing conventions, or let the loop populate it.
+4. Run the loop whenever a {{SIGNAL_NOUN}} arrives — see `AGENT_GUIDE.md`.
+
+## Kit invariants
+
+- **One {{RULE_NOUN}} = one entry** with a slug ID, testable statement, rationale, tags, source, Do/Don't.
+- **Slug IDs** (`{{RULE_PREFIX}}-CORE-<slug>`, `{{SIGNAL_PREFIX}}-YYYYMMDD-<slug>`) — no shared counter, no collisions.
+- **Core holds only universals;** context-specific rules are deltas. No two accepted {{RULE_NOUN_PLURAL}} may directly conflict.
+- **Human approval mandatory** in every mode; respect the promotion threshold.
+- **Every {{RULE_NOUN}} traces to evidence** (a `{{SIGNAL_LOG}}` ID; `baseline` only for seeds).
+- **Deprecate, don't delete** — Archive section keeps the active (ENFORCE) list lean.
+- **{{REVIEW_CADENCE}} re-review** of {{RULE_NOUN_PLURAL}} with `Last reviewed` > 90 days; archive prior-year signals in the same pass.

--- a/_templates/learning-loop-kit/base/_templates/rule-entry.md
+++ b/_templates/learning-loop-kit/base/_templates/rule-entry.md
@@ -1,0 +1,32 @@
+# {{RULE_NOUN}} Entry Template
+
+Copy this block into the right layer file during the PROMOTE step.
+
+## ID scheme (collision-free + discoverable)
+Use a **kebab-case slug**, not a running number: `{{RULE_PREFIX}}-<LAYER>-<slug>`.
+- e.g. `{{RULE_PREFIX}}-CORE-<slug>`.
+- Slugs never collide on concurrent appends (no shared counter) and read as their own index.
+- If a slug is already taken, the {{RULE_NOUN}} already exists — update it instead of duplicating.
+
+```markdown
+### {{RULE_PREFIX}}-<LAYER>-<slug> — <one-line imperative title>
+- **Statement:** <single testable rule — what must be true>
+- **Rationale:** <why this matters; the cost of violating it> [Source: <signal IDs or standard>]
+- **Layer:** <one of {{LAYERS}}>
+- **Tags:** <1-3 topic tags, for INDEX.md>
+- **Source {{SIGNAL_NOUN}}:** <{{SIGNAL_PREFIX}}-YYYYMMDD-slug[, ...]> | baseline
+- **Do:** <concrete positive example>
+- **Don't:** <concrete anti-example>
+- **Check:** <{{MACHINE_ENCODING}} reference if machine-checkable, else —>
+- **Status:** proposed | accepted | deprecated
+- **Added:** YYYY-MM-DD · **Last reviewed:** YYYY-MM-DD
+<!-- if deprecated: move under the file's `## Archive (deprecated)` section and add: -->
+- **Superseded by:** {{RULE_PREFIX}}-<LAYER>-<slug>
+```
+
+## Rules
+- **Statement must be testable.** A reviewer (human or a {{GATE_SKILLS}} agent) can decide pass/fail.
+- **Layering:** put it in `core` only if true across all of {{LAYERS}}; otherwise it is a delta and must not contradict an accepted `core` {{RULE_NOUN}}.
+- **No {{RULE_NOUN}} without evidence:** `Source {{SIGNAL_NOUN}}` is required (`baseline` only for seeded defaults).
+- **Tags are mandatory** — they drive `INDEX.md` discoverability past a handful of {{RULE_NOUN_PLURAL}}.
+- **Deprecate, don't delete:** move superseded entries to `## Archive (deprecated)` so the active list (what ENFORCE reads) stays lean.

--- a/_templates/learning-loop-kit/base/_templates/signal-entry.md
+++ b/_templates/learning-loop-kit/base/_templates/signal-entry.md
@@ -1,0 +1,30 @@
+# {{SIGNAL_NOUN}} Entry Template
+
+Append this block to `{{SIGNAL_LOG}}` during CAPTURE (fill `status: new`; leave Analysis/Proposed blank until ANALYZE).
+
+## ID scheme (collision-free)
+`{{SIGNAL_PREFIX}}-<YYYYMMDD>-<slug>` — capture date + short kebab mnemonic.
+- Date + slug avoids the shared-counter collision that plain `-NNN` causes on same-day concurrent logging.
+
+```markdown
+### {{SIGNAL_PREFIX}}-YYYYMMDD-<slug>
+- **Date:** YYYY-MM-DD
+- **Source:** <one of {{SIGNAL_SOURCES}}>
+- **Layer:** <one of {{LAYERS}}>
+- **Raw {{SIGNAL_NOUN}}:** "<verbatim or close paraphrase — keep original words>"
+- **Analysis:** <ANALYZE: theme cluster + severity; blank until analyzed>
+- **Proposed {{RULE_NOUN}}:** <{{RULE_PREFIX}}-...-slug draft, or 'none'; blank until analyzed>
+- **Status:** new | analyzed | promoted | rejected
+- **Reviewed by:** <human, REVIEW step> · **Decision date:** YYYY-MM-DD
+<!-- if promoted: -->
+- **Promoted to:** {{RULE_PREFIX}}-<LAYER>-<slug>
+<!-- if rejected: -->
+- **Reject reason:** <why — e.g. below threshold, out of scope, contradicts {{RULE_PREFIX}}-...>
+```
+
+## Rules
+- **Keep original words** in Raw {{SIGNAL_NOUN}} — interpretation belongs in Analysis.
+- **Promotion threshold:** {{PROMOTION_THRESHOLD}}. Below that → mark `analyzed` and leave to accumulate; don't promote one-offs.
+- **One signal ≠ one law.** A lone low-severity item can be `analyzed` then `rejected` with a reason; the rejection is useful history.
+- **Tag the Layer** so ANALYZE knows whether the resulting {{RULE_NOUN}} is core or a delta.
+- **Archive yearly:** move resolved prior-year entries to a `<{{SIGNAL_LOG}} basename>-<YEAR>.md` sibling when the log grows large.

--- a/_templates/learning-loop-kit/base/artifacts/README.md
+++ b/_templates/learning-loop-kit/base/artifacts/README.md
@@ -1,0 +1,18 @@
+<!-- If ARTIFACT_NOUN is `none`, delete this directory when rendering. Otherwise rename to {{ARTIFACT_DIR}}/. -->
+# {{ARTIFACT_NOUN}}s
+
+Evidence that demonstrates a {{RULE_NOUN}}. Supporting artifacts, not the source of truth — the rule files are. Store reference {{ARTIFACT_NOUN}}s and Before/After pairs here.
+
+## Naming convention
+```
+{{ARTIFACT_DIR}}/
+  {{RULE_PREFIX}}-CORE-<slug>__do.<ext>
+  {{RULE_PREFIX}}-CORE-<slug>__dont.<ext>
+  {{SIGNAL_PREFIX}}-YYYYMMDD-<slug>__before.<ext>
+  {{SIGNAL_PREFIX}}-YYYYMMDD-<slug>__after.<ext>
+```
+- Prefix with the **{{RULE_NOUN}} slug** or **{{SIGNAL_NOUN}} ID** it belongs to so links never rot.
+- Use `__do` / `__dont` / `__before` / `__after` suffixes for comparisons.
+
+## Linking
+Reference {{ARTIFACT_NOUN}}s from rule entries (`rules/*.md`) and signal entries by filename.

--- a/_templates/learning-loop-kit/base/rules/INDEX.md
+++ b/_templates/learning-loop-kit/base/rules/INDEX.md
@@ -1,0 +1,16 @@
+# {{RULE_NOUN_PLURAL}} Index
+
+Discoverability layer over the rule files in `{{LAYERS}}`. **Before doing domain work, scan this by tag** instead of reading every file. The PROMOTE step adds each new {{RULE_NOUN}}'s row; the periodic re-review (see `../README.md`) prunes deprecated rows.
+
+## By tag
+
+| Tag | {{RULE_NOUN_PLURAL}} |
+|-----|----------------------|
+| <tag> | {{RULE_PREFIX}}-CORE-example |
+
+## By layer
+
+| Layer | {{RULE_NOUN_PLURAL}} (accepted) |
+|-------|----------------------------------|
+| core | {{RULE_PREFIX}}-CORE-example |
+<!-- one row per layer in {{LAYERS}} -->

--- a/_templates/learning-loop-kit/base/rules/core.md
+++ b/_templates/learning-loop-kit/base/rules/core.md
@@ -1,0 +1,26 @@
+# Core {{RULE_NOUN_PLURAL}} (universal)
+
+Binding across all of `{{LAYERS}}`. Delta layers may add context-specific {{RULE_NOUN_PLURAL}} but must not contradict these. Each entry follows `_templates/rule-entry.md`. IDs are slugs (`{{RULE_PREFIX}}-CORE-<slug>`) — see `INDEX.md`.
+
+> Status legend: `proposed` (awaiting human review — NOT binding) · `accepted` (binding) · `deprecated` (moved to Archive below).
+
+<!-- Seed 1-3 baseline {{RULE_NOUN_PLURAL}} here (Source: baseline) so the kit is usable before signals accumulate. Example skeleton: -->
+
+### {{RULE_PREFIX}}-CORE-example — <imperative title>
+- **Statement:** <testable rule>
+- **Rationale:** <why> [Source: baseline]
+- **Layer:** core
+- **Tags:** <tag>
+- **Source {{SIGNAL_NOUN}}:** baseline
+- **Do:** <example>
+- **Don't:** <anti-example>
+- **Check:** —
+- **Status:** accepted · **Added:** YYYY-MM-DD · **Last reviewed:** YYYY-MM-DD
+
+---
+
+<!-- PROMOTE appends new accepted {{RULE_NOUN_PLURAL}} above this line. For each delta layer in {{LAYERS}}, create a sibling file (e.g. frontend.md) with prefix {{RULE_PREFIX}}-<LAYER>-<slug>. -->
+
+## Archive (deprecated)
+
+<!-- Superseded {{RULE_NOUN_PLURAL}} move here (keep full entry + `Superseded by:`). ENFORCE ignores this section. -->

--- a/_templates/learning-loop-kit/base/signals-log.md
+++ b/_templates/learning-loop-kit/base/signals-log.md
@@ -1,0 +1,13 @@
+<!-- Rename this file to {{SIGNAL_LOG}} when rendering the kit. -->
+# {{SIGNAL_NOUN}} Log (append-only)
+
+The audit trail of every {{SIGNAL_NOUN}} and what became of it. **Never edit history; only append and update `status`/`promoted-to`.** Each entry follows `_templates/signal-entry.md`.
+
+> Status flow: `new` → `analyzed` → (`promoted` | `rejected`). A `promoted` entry links to the {{RULE_NOUN}} slug it produced.
+> ID format: `{{SIGNAL_PREFIX}}-YYYYMMDD-<slug>` (date + mnemonic — collision-free).
+> Promotion threshold: {{PROMOTION_THRESHOLD}}.
+> Archive: move resolved prior-year entries to a `<this-file-basename>-<YEAR>.md` sibling when this file grows large.
+
+---
+
+<!-- New {{SIGNAL_NOUN_PLURAL}} are appended below by CAPTURE with status: new. -->

--- a/_templates/learning-loop-kit/instances/design-feedback.config.md
+++ b/_templates/learning-loop-kit/instances/design-feedback.config.md
@@ -1,0 +1,48 @@
+# Kit Config — Design Feedback
+
+The config for **instance #1**, `_templates/design-feedback-kit/`. ⚠ The shipped kit **predates this base** and is a **non-strict render** — it was hand-authored first, then generalized into the base. It is NOT byte-for-byte reproducible from `base/` because of two intentional vocabulary differences:
+
+| Concept | base/ token | shipped design-feedback-kit |
+|---------|-------------|------------------------------|
+| layer/partition field | `Layer:` | `Scope:` |
+| machine-check field | `Check:` | `Token:` |
+
+The base names (`Layer` / `Check`) are the generic forms; the shipped kit's `Scope` / `Token` are domain-flavored. **A fresh render of this config would produce `Layer` / `Check`** — that is correct and expected. Do not "fix" the shipped kit to match; leave it as the predecessor. New kits use the base vocabulary.
+
+This config documents the knob values; the shipped kit is the worked example of the *rendered shape*, not a guaranteed identical output.
+
+```yaml
+# --- identity ---
+KIT_NAME:            "Design Feedback"
+KIT_SLUG:            "design-feedback"
+DOMAIN_DIR:          "design"
+
+# --- vocabulary ---
+RULE_NOUN:           "principle"
+RULE_NOUN_PLURAL:    "principles"
+RULE_PREFIX:         "P"                          # P-CORE-control-feedback
+SIGNAL_NOUN:         "feedback"
+SIGNAL_NOUN_PLURAL:  "feedback"
+SIGNAL_PREFIX:       "FB"                          # FB-20260115-double-save
+SIGNAL_LOG:          "feedback-log.md"
+ARTIFACT_NOUN:       "mockup"
+ARTIFACT_DIR:        "mockups"
+
+# --- structure ---
+LAYERS:              ["core", "frontend", "ios", "android"]
+
+# --- enums ---
+SIGNAL_SOURCES:      ["interview", "usability-test", "review", "support-ticket", "analytics", "app-store-review", "echo-walkthrough"]
+
+# --- skill wiring ---
+ANALYZE_SKILLS:      ["voice", "echo", "palette"]
+PROMOTE_SKILLS:      ["muse", "vision", "lore"]
+ENFORCE_SKILLS:      ["vision", "artisan", "flow", "prose", "native"]
+GATE_SKILLS:         ["guardian", "canon", "judge"]
+
+# --- policy ---
+PROMOTION_THRESHOLD: ">=2 independent items OR 1 high-severity (data loss / blocked task / a11y blocker)"
+MACHINE_ENCODING:    "design token via muse"
+REVIEW_CADENCE:      "quarterly"
+```
+

--- a/_templates/learning-loop-kit/kit.config.template.md
+++ b/_templates/learning-loop-kit/kit.config.template.md
@@ -1,0 +1,45 @@
+# Kit Config — <KIT_NAME>
+
+Fill every knob, then render `base/` into `<kit-slug>-kit` by substituting each `{{TOKEN}}`. One config = one instance. Keep this file with the rendered kit so the instance is reproducible.
+
+```yaml
+# --- identity ---
+KIT_NAME:            "<Human Name, e.g. Review Knowledge>"
+KIT_SLUG:            "<kebab, e.g. review-knowledge>"
+DOMAIN_DIR:          "<install dir in target repo, e.g. review>"
+
+# --- vocabulary ---
+RULE_NOUN:           "<singular, e.g. convention>"
+RULE_NOUN_PLURAL:    "<plural, e.g. conventions>"
+RULE_PREFIX:         "<short, e.g. C>"          # rule slug: <RULE_PREFIX>-<LAYER>-<slug>
+SIGNAL_NOUN:         "<singular, e.g. review comment>"
+SIGNAL_NOUN_PLURAL:  "<plural, e.g. review comments>"
+SIGNAL_PREFIX:       "<short, e.g. RC>"         # signal id: <SIGNAL_PREFIX>-YYYYMMDD-<slug>
+SIGNAL_LOG:          "<filename, e.g. comments-log.md>"
+ARTIFACT_NOUN:       "<evidence noun, e.g. example | snippet | repro | none>"
+ARTIFACT_DIR:        "<dir, e.g. examples | none>"
+
+# --- structure ---
+LAYERS:              ["core"]                    # flat. OR e.g. ["core","frontend","ios","android"]
+                                                 # core = universal; others = deltas that must not contradict core
+
+# --- enums ---
+SIGNAL_SOURCES:      ["<source-a>", "<source-b>", "..."]   # allowed Source: values for a signal
+
+# --- skill wiring (loop steps → specialists) ---
+ANALYZE_SKILLS:      ["<skill>", "..."]          # cluster signals, draft rules
+PROMOTE_SKILLS:      ["<skill>", "..."]          # curate, dedup, encode
+ENFORCE_SKILLS:      ["<skill>", "..."]          # read rules before acting
+GATE_SKILLS:         ["<skill>", "..."]          # PR gate
+
+# --- policy ---
+PROMOTION_THRESHOLD: "<when a theme becomes a rule, e.g. '>=2 independent items OR 1 high-severity'>"
+MACHINE_ENCODING:    "<how quantitative rules auto-check, e.g. 'lint rule (Semgrep)' | 'design token' | 'alert rule' | 'none'>"
+REVIEW_CADENCE:      "quarterly"                 # re-validate rules whose Last reviewed > 90d
+```
+
+## Notes per knob
+- **RULE_PREFIX / SIGNAL_PREFIX** must be unique within the kit and short. Slugs (not numbers) keep IDs collision-free under concurrent appends.
+- **LAYERS** — choose `["core"]` (flat) unless the domain genuinely has a universal layer + context-specific deltas. Common axes: platform, service, language, audience.
+- **MACHINE_ENCODING** decides how much of ENFORCE is mechanical vs reviewer-judgment. If `none`, the PR gate is human-judgment only — state that honestly in the rendered `AGENT_GUIDE.md`.
+- **ARTIFACT_NOUN: none** drops the artifacts directory entirely (some domains have no visual/asset evidence).


### PR DESCRIPTION
## Summary
A parameterized base for repo-local **learning loops** — mechanisms that turn a recurring stream of signals (feedback, review comments, incidents, findings…) into durable, versioned rules that agents enforce on future work. Generalizes `design-feedback-kit` (instance #1) so any domain with the same loop shape can be instantiated in minutes.

Loop machinery (CAPTURE → ANALYZE → REVIEW → PROMOTE → ENFORCE, slug IDs, Archive, threshold, PR gate, audit trail) is shared; only 16 domain knobs differ.

## Changes
- `README.md` — pattern, knobs, scriptable-vs-manual instantiate steps, fit/non-fit
- `kit.config.template.md` — the 16-knob config form
- `INSTANCES.md` — registry (instance #1 + 8 ranked candidate domains)
- `base/` — `{{TOKEN}}`-parameterized template files (README, AGENT_GUIDE, CLAUDE.snippet, signals-log, rules/{INDEX,core}, artifacts, _templates/{rule,signal}-entry)
- `_scripts/check-rendered.sh` — render gate: flags unrendered `{{TOKEN}}` / date / skeleton residue
- `instances/design-feedback.config.md` — worked-example config (documents the predecessor / non-strict-render vocabulary delta)

## Testing
- [x] Docs/templates + one shell checker — no app code
- [x] Token hygiene: all 20 base tokens defined in config (grep verified)
- [x] `check-rendered.sh` syntax OK; correctly reports residue on unrendered `base/`
- [x] No Japanese in deliverables (English-only, per repo convention)

## Notes
`design-feedback-kit` is intentionally a **non-strict render** (uses `Scope:`/`Token:` vs base `Layer:`/`Check:`) — documented, not to be "fixed". New kits use base vocabulary.