### PR TITLE
feat(nexus): optimize for Codex CLI as orchestrator

### DIFF
--- a/_common/CLI_COMPATIBILITY.md
+++ b/_common/CLI_COMPATIBILITY.md
@@ -105,6 +105,8 @@ Direct model names are CLI-specific. Authoring tip: write SKILL.md with role nam
 
 > agy explicitly lists Claude Sonnet 4.6 / Opus 4.6 (Thinking) and GPT-OSS 120B in `/model`. Source: Medium "Getting Started" + tutorial series (2026-05).
 
+> **Codex-as-orchestrator effort routing**: when Codex CLI drives the hub, apply Plan-and-Execute by **model choice** — planning / high-complexity steps → `gpt-5.1-codex-max`, execution steps → `gpt-5.1`. The exact Codex reasoning-effort config key name and its level names are **未確認**; do not invent an effort enum. Full Codex-hub authoring protocol: `_common/CODEX_ORCHESTRATION.md` (C3).
+
 ---
 
 ## 5. Permission Models

--- a/_common/CODEX_ORCHESTRATION.md
+++ b/_common/CODEX_ORCHESTRATION.md
@@ -1,0 +1,139 @@
+# Codex Orchestration Authoring Protocol
+
+> Counterpart to `_common/OPUS_48_AUTHORING.md`. That file governs authoring when **Claude Code** drives the Nexus hub; this file governs authoring when **Codex CLI** drives the hub.
+> Owner: Architect (canonical doc); referenced by orchestrators (Nexus, Orbit, Rally, Arena, Magi) and any SKILL.md whose spawn path can run on Codex CLI.
+> Scope: Codex CLI as the **orchestrator engine** (the CLI running the top-level hub session). Codex as a *worker / spawn target* of a Claude hub is covered by `_common/SUBAGENT.md` (MULTI_ENGINE) and `_common/MULTI_ENGINE_RECIPE.md`.
+
+Engine-selection rule for orchestrators:
+
+| Orchestrator engine (hub) | Authoring protocol |
+|---------------------------|--------------------|
+| Claude Code | `_common/OPUS_48_AUTHORING.md` (P1–P11) |
+| **Codex CLI** | **this file (C1–C8)** |
+| Antigravity (`agy`) | best-effort; no dedicated protocol yet — apply C-principles by analogy, treat `/agent` constraints per `_common/CLI_COMPATIBILITY.md §3, §9` |
+
+---
+
+## Why This Exists
+
+The Nexus stack historically assumed Claude Code is the hub: the canonical spawn template is `Agent(...)`, model selection is `sonnet/opus/haiku`, parallelism is `run_in_background`, and the authoring protocol is Opus-4.8-specific (effort levels, P4 parallel triggers). None of those map cleanly to a Codex CLI hub, which spawns via `spawn_agent`/`wait_agent`, selects `gpt-5.1` / `gpt-5.1-codex-max`, has **no background-spawn primitive**, and gates fan-out via `agents.max_depth` rather than a soft "max 3" convention.
+
+When Codex drives the hub, apply the eight principles below instead of the Opus principles. They are grounded only in verified repository facts (`_common/CLI_COMPATIBILITY.md`, `nexus/SKILL.md` Execution Layers); items with no confirmed source are marked **未確認** and must not be speculatively completed.
+
+---
+
+## The Eight Principles
+
+### C1. Spawn-Depth Budget
+
+Codex gates nested spawning with `agents.max_depth` (default `1`). A hub that itself was spawned (e.g. Nexus launched from a slash command) may already sit at depth 1 and be unable to recurse.
+
+**Apply by:**
+- Before the first `spawn_agent` of a chain, verify both prereqs hold: `codex features list | grep multi_agent` → `true` (default since v0.115+), and `~/.codex/config.toml` has `[agents] max_depth >= 2`.
+- If `max_depth` is insufficient, fall back to internal execution and log the reason concretely (`Execution: internal (reason: agents.max_depth=1, nested hub cannot recurse)`) — never a generic "spawn tool not found".
+- Treat depth as the real fan-out governor; the `_common/SUBAGENT.md` "max 3 parallel" convention is a Claude soft-cap, not the Codex limit.
+
+### C2. Synchronous Fan-Out / Join
+
+Codex has **no background-spawn primitive**. Parallelism = issue N `spawn_agent` calls in one turn, then `wait_agent` on **all** of them. This is a hard barrier, unlike Claude's non-blocking `run_in_background`.
+
+**Apply by:**
+- For 2-3 independent branches: emit all `spawn_agent` calls together, then join with `wait_agent` per id before aggregating.
+- Do not design recipes that assume a branch can keep running while the hub does other work — Codex joins at `wait_agent`.
+- Hub-spoke ownership still holds: no shared mutable state between concurrent branches; aggregate only after the join.
+
+### C3. Reasoning-Effort Routing
+
+Apply Plan-and-Execute across Codex models: a high-reasoning model plans, a cheaper default model executes (Core Contract cost principle).
+
+**Apply by:**
+- Planning / high-complexity design steps → `gpt-5.1-codex-max` (reasoning).
+- Standard implementation / execution steps → `gpt-5.1` (default).
+- The exact Codex reasoning-effort config key name and its level names are **未確認** in current docs — express effort as model choice (codex-max vs default), not as an invented effort enum.
+
+### C4. Loose-Prompt Spawning
+
+Codex subagents perform best with minimal, unbiased framing — **Role / Target / Output** only (`_common/SUBAGENT.md` MULTI_ENGINE loose-prompt rule). Over-specifying with checklists, category lists, or methodology descriptions suppresses Codex's independent perspective.
+
+**Apply by:**
+- Pass the CLI-agnostic spawn template body (Role, Task, Context delta, Constraints, Acceptance criteria, Output envelope) but resist padding it with domain frameworks the specialist's own SKILL.md already supplies.
+- The specialist reads its own `SKILL.md` (`~/.codex/skills/` or `<repo>/.agents/skills/`); do not duplicate that content into the spawn prompt.
+
+### C5. Lazy Tool Visibility
+
+Codex does not always list `spawn_agent` in the model's visible tool inventory. "Not visible" ≠ "not callable".
+
+**Apply by:**
+- If both C1 prereqs hold but `spawn_agent` appears absent, attempt the call anyway rather than falling back to internal.
+- Only log an internal fall-back after an actual call failure, with the concrete error.
+
+### C6. Checkpoint-Resume via Session Tools
+
+For chains with 4+ steps (the SKILL checkpoint-resume threshold), continue an existing subagent instead of re-spawning.
+
+**Apply by:**
+- Use `send_input` to feed the next step's delta into a live subagent, and `resume_agent` to revive a checkpointed one, rather than spawning a fresh session each step.
+- Call `close_agent` to release a finished subagent's context and keep the depth/budget envelope clear.
+- Omitted spawn fields inherit from the parent session — pass only the state delta, not the full context.
+
+### C7. Sandbox / Approval Posture
+
+Codex runs sandbox-on by default. An autonomous hub must set an approval policy consistent with the active Nexus mode.
+
+**Apply by:**
+- AUTORUN / AUTORUN_FULL → `codex exec --full-auto` (or equivalent config) so subagents proceed without per-action prompts.
+- Never use `--dangerously-bypass-approvals-and-sandbox` in production or untrusted workspaces; restrict to sandboxed/CI/authorized-dev contexts.
+- Guided / Interactive modes keep the default per-action approval; do not silently widen it.
+
+### C8. AGENTS.md Authority
+
+Codex reads `AGENTS.md` (`~/.codex/AGENTS.md` global, `<repo>/AGENTS.md` project) — **not** `CLAUDE.md`. Output language, commit conventions, and naming rules come from there.
+
+**Apply by:**
+- Resolve output-language and convention directives from `AGENTS.md`, not from a `CLAUDE.md` assumption.
+- When authoring cross-CLI skills, keep shared rules in `AGENTS.md` (per `_common/CLI_COMPATIBILITY.md §7`) so a Codex hub inherits them.
+
+---
+
+## Per-Role Apply Matrix
+
+| Role | Critical (◎) | Recommended (○) |
+|------|---|---|
+| Orchestrators (Nexus, Orbit, Rally, Arena, Magi, Titan, Sherpa) | C1, C2, C6 | C3, C7 |
+| Builders / executors (Builder, Artisan, Forge, Native) spawned by a Codex hub | C4, C5 | C3 |
+| Investigators / reviewers spawned by a Codex hub | C4 | C6 |
+| Knowledge/Meta (Lore, Compass, Architect) authoring for Codex hubs | C3, C8 | C1 |
+
+(◎ = address explicitly in SKILL.md; ○ = address if relevant)
+
+C8 (AGENTS.md authority) applies to **every** role authored for a Codex hub.
+
+---
+
+## Validation Hooks
+
+When validating a skill's Codex-orchestrator path, use the eight checks below (Architect validation):
+
+- R-C1 Spawn-depth prereqs verified before fan-out; concrete internal fall-back reason
+- R-C2 Parallel branches use N `spawn_agent` → `wait_agent` join (no assumed background execution)
+- R-C3 Effort expressed as model choice (codex-max plan / default execute); no invented effort enum
+- R-C4 Loose-prompt spawn (Role/Target/Output); no methodology padding
+- R-C5 Lazy-visibility handling (attempt call when prereqs hold)
+- R-C6 Checkpoint-resume via `send_input`/`resume_agent`/`close_agent` for 4+ step chains
+- R-C7 Approval posture matches the active Nexus mode; no prod bypass flags
+- R-C8 Rules resolved from `AGENTS.md`, not `CLAUDE.md`
+
+Pass criterion: address all `◎` principles for the role; aim for ≥ 6/8 total.
+
+---
+
+## How to Reference This File
+
+In a SKILL.md:
+
+```markdown
+- Author for the active orchestrator engine. Claude Code hub → `_common/OPUS_48_AUTHORING.md`;
+  Codex CLI hub → `_common/CODEX_ORCHESTRATION.md` (apply C[X], C[Y] for this role).
+```
+
+Cite by ID (C1–C8); let this file be the single source of truth. Do not duplicate principle text into individual SKILL.md files.

--- a/_common/SUBAGENT.md
+++ b/_common/SUBAGENT.md
@@ -93,6 +93,22 @@ Agent(subagent_type="Explore", prompt="Research area C...")
 
 ---
 
+## Codex Orchestrator Parallelism
+
+This document assumes the **Claude Code** `Agent` tool. When the **Codex CLI** drives the hub, the parallelism primitives differ — apply `_common/CODEX_ORCHESTRATION.md` instead of the Agent mechanics above:
+
+| Concept | Claude Code (this doc) | Codex CLI hub |
+|---------|------------------------|---------------|
+| Spawn | `Agent(prompt, ...)` | `spawn_agent(prompt)` → `wait_agent(id)` |
+| Parallel | N `Agent(... run_in_background: true)` (non-blocking) | N `spawn_agent` in one turn → `wait_agent` on **all** (hard join; no background primitive — C2) |
+| Max fan-out | soft cap **3** (else Rally) | governed by `agents.max_depth` / budget (C1), not the soft 3 |
+| Continue / resume | new `Agent` per step | `send_input` / `resume_agent` / `close_agent` for 4+ step chains (C6) |
+| Prereq | `Agent` tool present | `[features] multi_agent = true` + `[agents] max_depth >= 2`; tool may be lazily hidden (C5) |
+
+The patterns below (RESEARCH_FAN_OUT, MULTI_ENGINE, etc.) and their merge strategies are engine-agnostic — only the spawn/join syntax changes.
+
+---
+
 ## Patterns
 
 ### RESEARCH_FAN_OUT

--- a/nexus/SKILL.md
+++ b/nexus/SKILL.md
@@ -36,7 +36,7 @@ PROJECT_AFFINITY: Game(H) SaaS(H) E-commerce(H) Dashboard(H) Marketing(H)
 
 > **"The right agent at the right time changes everything."**
 
-Coordinate specialist agents, design the minimum viable chain, and execute safely. `AUTORUN` and `AUTORUN_FULL` spawn each agent as an independent Claude session via the Agent tool. `Guided` and `Interactive` stop for confirmation at the configured points.
+Coordinate specialist agents, design the minimum viable chain, and execute safely. `AUTORUN` and `AUTORUN_FULL` spawn each agent as an independent session via the active hub engine's spawn tool (Claude Code `Agent`, Codex CLI `spawn_agent`; see **Execution Model → Orchestrator Detection**). `Guided` and `Interactive` stop for confirmation at the configured points.
 
 ## Trigger Guidance
 
@@ -64,7 +64,7 @@ Route elsewhere when the task is primarily:
 - Verify acceptance criteria before delivery; pair quantitative metrics with human evaluation for high-stakes tasks. [Source: aws.amazon.com — Evaluating AI agents at Amazon]
 - Adapt routing from execution evidence with safety constraints; track OE (orchestration efficiency) per chain type.
 - Leverage standardized inter-agent protocols where available: MCP (Anthropic), A2A (Google), ACP (IBM). [Source: arxiv.org/html/2601.13671v1]
-- Apply Plan-and-Execute pattern: capable models (opus) for planning, cheaper models (sonnet/haiku) for execution — up to 90% cost reduction. [Source: machinelearningmastery.com]
+- Apply Plan-and-Execute pattern: capable models for planning, cheaper models for execution — up to 90% cost reduction. Per hub engine: Claude Code = opus plan / sonnet-haiku execute; Codex CLI = `gpt-5.1-codex-max` plan / `gpt-5.1` execute (`CODEX_ORCHESTRATION.md` C3). [Source: machinelearningmastery.com]
 - Use Anthropic's **Managed Agents** vocabulary (SF 2026): **Multiagent Orchestration** for hub-and-spoke fan-out, **Outcomes** for rubric-scored Evaluator Loops, **Dreaming** for Lore-driven memory curation, **Webhooks** for completion notifications via Mend / Beacon. Surface escalation recommendation in `NEXUS_COMPLETE` when the workload pattern (unattended multi-day runs, cross-user knowledge persistence, platform-level audit) justifies the managed platform. [Source: claude.com — *New in Claude: Managed Agents*; *Code with Claude SF 2026*]
 - Prefer **Dynamic Workflows** (Claude Code-native, research preview) as the *execution substrate* for large homogeneous parallel sweeps — codebase-wide audits, thousand-file migrations, verification-critical runs — and keep Nexus as the routing/recipe layer (which specialists, what shape). A Recipe step that is a large parallel sweep may delegate execution to a native dynamic workflow (or the `ultracode` setting: `xhigh` + auto-deploy) when available; fall back to L2/L3 spawn + hierarchical decomposition otherwise. See `references/managed-agents-mapping.md` §5. [Source: claude.com — *Introducing Dynamic Workflows in Claude Code*]
 - Output language follows the CLI global config (`settings.json` `language` field, `CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`); identifiers and technical terms remain in English.
@@ -80,7 +80,10 @@ Route elsewhere when the task is primarily:
 7. **Learn only from evidence.** Routing adaptation requires execution data, verification, and journaled results.
 8. **Prevent circular handoffs.** Enforce max-hop limits (default: 2 round-trips per agent pair) to prevent A→B→A handoff loops. [Source: codebridge.tech]
 9. **Hierarchical decomposition for scale.** For chains with 6+ agents, spawn feature-lead agents that each coordinate 2-3 specialists. [Source: addyosmani.com]
-10. **Author for Opus 4.8 defaults.** Apply `_common/OPUS_48_AUTHORING.md` principles **P4 (parallel subagent triggers), P6 (effort-level awareness), P7 (delegation framing), P9 (effort-calibrated tool use)**. Opus 4.8 spawns fewer subagents and reasons more by default, respects `effort` strictly, and follows instructions literally — explicit fan-out triggers, per-step model/effort selection, and explicit step scope are mandatory. Spawn prompts must state thinking nudges (P5) and length envelopes (P2).
+10. **Author for the active orchestrator engine.** Detect which CLI drives the hub (see **Execution Model → Orchestrator Detection**) and apply the matching authoring protocol:
+    - **Claude Code hub** → `_common/OPUS_48_AUTHORING.md` principles **P4 (parallel subagent triggers), P6 (effort-level awareness), P7 (delegation framing), P9 (effort-calibrated tool use)**. Opus 4.8 spawns fewer subagents and reasons more by default, respects `effort` strictly, and follows instructions literally — explicit fan-out triggers, per-step model/effort selection, and explicit step scope are mandatory. Spawn prompts must state thinking nudges (P5) and length envelopes (P2).
+    - **Codex CLI hub** → `_common/CODEX_ORCHESTRATION.md` principles **C1 (spawn-depth budget), C2 (synchronous fan-out/join), C6 (checkpoint-resume)**, plus C3/C7 for model and approval posture. Codex has no background-spawn primitive (parallel = N `spawn_agent` → `wait_agent` all), gates fan-out via `agents.max_depth`, and routes effort by model choice (`gpt-5.1-codex-max` plan / `gpt-5.1` execute) — not by an Opus `effort` enum.
+    - **agy hub** → best-effort; apply the C-principles by analogy under `_common/CLI_COMPATIBILITY.md §3, §9` constraints.
 
 ## Boundaries
 
@@ -272,6 +275,18 @@ Recipes with `Read` references in the Recipes table follow those references for 
 
 **Default: spawn.** Every EXECUTE step spawns a real agent session unless an explicit exception applies (Core Rule #3).
 
+### Orchestrator Detection
+
+Before the first spawn, determine which CLI drives **this hub session**, then bind the spawn API, authoring protocol, and model map accordingly. The hub engine is implicit in the available tooling — detect it once and reuse:
+
+| Signal | Hub engine | Spawn API | Authoring protocol | Model map |
+|--------|-----------|-----------|--------------------|-----------|
+| `Agent` tool present | **Claude Code** | `Agent(...)` (L1 fg / L2 `run_in_background`) | `_common/OPUS_48_AUTHORING.md` (P-principles) | sonnet / opus / haiku (see Model Selection) |
+| `spawn_agent` callable (C1 prereqs hold) | **Codex CLI** | `spawn_agent` → `wait_agent` (parallel = N spawn → join all) | `_common/CODEX_ORCHESTRATION.md` (C-principles) | `gpt-5.1` / `gpt-5.1-codex-max` (see `CLI_COMPATIBILITY.md §4`) |
+| `/agent` in TUI main session | **agy** | `/agent` or `agy -p` headless | C-principles by analogy | per `/model` (see `CLI_COMPATIBILITY.md §4`) |
+
+Codex-hub prereqs (C1): `codex features list \| grep multi_agent` → `true`, and `~/.codex/config.toml` `[agents] max_depth >= 2`. If unmet → internal execution with a concrete reason (`agents.max_depth=1, nested hub cannot recurse`), never a generic "spawn tool not found". `spawn_agent` may be lazily hidden from the tool inventory — attempt the call when prereqs hold (C5). Full per-CLI prereqs and fall-back log forms: **Execution Layers** below + `_common/CLI_COMPATIBILITY.md`.
+
 ### Spawn Decision Flow
 
 ```
@@ -373,12 +388,16 @@ EOF
 
 ### Model Selection
 
-| Agent Role | model | Rationale |
-|-----------|-------|-----------|
-| Investigation / read-only (Scout, Lens, Trail) | sonnet | Cost-efficient |
-| Standard implementation (Builder, Artisan, Radar) | sonnet | Balanced |
-| High-complexity design (Sentinel, Atlas) | opus | Precision-critical |
-| Lightweight tasks (Quill, Morph) | haiku | Minimal cost |
+Model names are hub-engine-specific. The role → tier mapping is stable; the concrete model per tier depends on the orchestrator engine (see **Orchestrator Detection** and `_common/CLI_COMPATIBILITY.md §4`).
+
+| Agent Role | Tier | Claude Code hub | Codex CLI hub | Rationale |
+|-----------|------|-----------------|---------------|-----------|
+| Investigation / read-only (Scout, Lens, Trail) | balanced | sonnet | `gpt-5.1` | Cost-efficient |
+| Standard implementation (Builder, Artisan, Radar) | balanced | sonnet | `gpt-5.1` | Balanced |
+| High-complexity design (Sentinel, Atlas) | high-reasoning | opus | `gpt-5.1-codex-max` | Precision-critical |
+| Lightweight tasks (Quill, Morph) | fast | haiku | lighter variant per docs | Minimal cost |
+
+> Codex hub: route planning / high-complexity steps to `gpt-5.1-codex-max` and execution steps to `gpt-5.1` (Plan-and-Execute, `CODEX_ORCHESTRATION.md` C3). The exact Codex reasoning-effort config key/levels are **未確認** — select effort via model choice, not an invented enum. agy hub: switch via `/model` in TUI (per-session, not per-agent).
 
 ### Agent Spawn Template
 
@@ -413,7 +432,24 @@ Agent(
 
 > **Opus 4.8 note**: The four directive fields above (acceptance criteria / output length / tool-use / thinking) are not optional. Opus 4.8 calibrates output length to context, restrains tool calls by default (raise `effort` to increase tool use), and interprets each field literally, so both under- and over-shoot occur when these are implicit. For parallel spawns, see **Core Rule #10** and **`_common/SUBAGENT.md`**, and issue multiple `Agent(... run_in_background: true)` calls in the same turn. Shared protocol: `_common/OPUS_48_AUTHORING.md`.
 
-**Codex CLI variant**: same prompt body; invoke via `spawn_agent(prompt=<body>)` then `wait_agent(id)`.
+**Codex CLI variant**: same prompt body; resolve the skill path to `~/.codex/skills/[agent]/SKILL.md` or `<repo>/.agents/skills/[agent]/SKILL.md`. The four directive fields stay required (they are CLI-agnostic), but Codex authoring follows `_common/CODEX_ORCHESTRATION.md` (C-principles), not the Opus note above — Codex routes effort by **model choice** (`gpt-5.1-codex-max` plan / `gpt-5.1` execute, C3), not an `effort` enum, and gates fan-out via `agents.max_depth` (C1), not a soft "max 3".
+
+```
+# L1 sequential
+id = spawn_agent(prompt=<body>)         # omitted fields inherit from parent session
+result = wait_agent(id)
+
+# L2 parallel — N spawn in one turn, then JOIN ALL (no background primitive; C2)
+ids = [spawn_agent(prompt=<body_i>) for i in branches]   # branches ≤ max_depth/budget
+results = [wait_agent(i) for i in ids]                    # hard barrier; aggregate after join
+
+# 4+ step chain — continue a live subagent instead of re-spawning (C6)
+send_input(id, <next_step_delta>)       # feed next step into the same session
+resume_agent(id)                        # revive a checkpointed subagent
+close_agent(id)                         # release context when the branch is done
+```
+
+Prereqs (C1): `[features] multi_agent = true` + `[agents] max_depth >= 2`. `spawn_agent` may be lazily hidden — attempt the call when prereqs hold (C5).
 
 **agy variant**: same prompt body; invoke via `/agent [agent]-[task-slug] "<body>"` (TUI) or `agy -p "<body>" --dangerously-skip-permissions --output-format json` (headless). The `--dangerously-skip-permissions` flag is mandatory in headless mode — without it, `request-review` will block the spawn. `--output-format json` is a hidden flag (absent from `--help` v1.0.2 but confirmed in official DEV.to examples). **Reference files in the prompt body with `@<path>`** (e.g. `@docs/spec.md`) to inject context into the main agent — bare path strings trigger silent subagent timeouts (60s cap, see Antigravity CLI section above). Replace skill path with `~/.gemini/antigravity-cli/skills/[agent]/SKILL.md` or `<repo>/.agents/skills/[agent]/SKILL.md`.
 
@@ -562,11 +598,12 @@ Read only the files that match the current decision point.
 | `references/summit-recipe.md` | `/nexus summit` — prereqs (agy OPTIONAL — dual-engine fallback when unavailable), engine × team matrix, phase contracts, arena sub-orchestration, Vision sub-orchestration of design specialists, multi-engine quorum rules, AUTORUN chain template, failure escalation, cost/latency profile, decision tree vs apex/judge |
 | `references/transmute-recipe.md` | `/nexus transmute` — cross-language rewrite (TS→Rust, Go→Rust, …). Migration strategy table (strangler-fig / FFI-incremental / big-bang), Phase 0-6 contract, the Transmutation Map (per-pair type/error/concurrency/memory idiom mappings), failure modes, add-ons, decision tree vs PORTING/shift/horizon |
 | `references/podium-recipe.md` | `/nexus podium` — five-team content workflow (Research / Narrative / Production / Verification / Improvement) for doc + high-quality slide creation. Engine × team matrix (Claude prose / Codex compile / agy imagery), phase contracts with output_format variants (doc / slide / both / notebooklm / figma-slides), claim-grounding via Attest, 6×6 + WCAG-AA + persona walkthrough gates, max-2 improvement loop, decision tree vs single-skill / atelier / summit |
-| `_common/OPUS_48_AUTHORING.md` | Designing spawn prompts, planning output envelopes, or selecting per-step model effort. Critical for orchestrators: P4 (parallel subagents), P6 (effort), P7 (delegation) |
+| `_common/OPUS_48_AUTHORING.md` | **Claude Code hub** — designing spawn prompts, planning output envelopes, or selecting per-step model effort. Critical for orchestrators: P4 (parallel subagents), P6 (effort), P7 (delegation) |
+| `_common/CODEX_ORCHESTRATION.md` | **Codex CLI hub** — spawn-depth budget (C1), synchronous fan-out/join via `spawn_agent`/`wait_agent` (C2), reasoning-effort-by-model routing (C3), checkpoint-resume via `send_input`/`resume_agent`/`close_agent` (C6). The Codex-hub counterpart to OPUS_48_AUTHORING |
 
 ## Operational Notes
 
-Follow `_common/OPERATIONAL.md`, `_common/AUTORUN.md`, `_common/HANDOFF.md`, `_common/GIT_GUIDELINES.md`, `_common/HARNESS_EVOLUTION.md`. Journal in `.agents/nexus.md`; log to `.agents/PROJECT.md`. No agent names in commits/PRs. Decompose, route, execute, verify, deliver. Keep chains small, handoffs structured, recovery explicit.
+Follow `_common/OPERATIONAL.md`, `_common/AUTORUN.md`, `_common/HANDOFF.md`, `_common/GIT_GUIDELINES.md`, `_common/HARNESS_EVOLUTION.md`. For the active orchestrator engine apply `_common/OPUS_48_AUTHORING.md` (Claude Code hub) or `_common/CODEX_ORCHESTRATION.md` (Codex CLI hub). Journal in `.agents/nexus.md`; log to `.agents/PROJECT.md`. No agent names in commits/PRs. Decompose, route, execute, verify, deliver. Keep chains small, handoffs structured, recovery explicit.
 
 ## AUTORUN Support
 


### PR DESCRIPTION
## Summary
Make Codex CLI a first-class orchestrator (hub) engine for Nexus. Previously the stack implicitly assumed Claude Code drives the hub and Codex appeared only as a spawn target / worker engine. This adds the Codex-hub authoring protocol and makes Nexus's authoring, model, spawn, and execution docs engine-aware.

## Changes
- **New `_common/CODEX_ORCHESTRATION.md`** — the Codex-hub counterpart to `OPUS_48_AUTHORING.md`. Principles C1–C8: spawn-depth budget, synchronous fan-out/join (`spawn_agent`×N → `wait_agent` all), reasoning-effort-by-model routing, loose-prompt spawning, lazy tool visibility, checkpoint-resume (`send_input`/`resume_agent`/`close_agent`), approval posture, AGENTS.md authority. Includes Per-Role Matrix + Validation Hooks.
- **`nexus/SKILL.md`** engine-aware in 5+ places — Core Rule #10 (per-engine protocol routing), new **Orchestrator Detection** section, hub-specific Model Selection table, a real Codex spawn template (fan-out + checkpoint-resume), Reference Map + Operational Notes. Intro and Plan-and-Execute Core Contract line de-hardcoded from Claude-only.
- **`_common/SUBAGENT.md`** — Codex Orchestrator Parallelism bridge table (Agent mechanics → `spawn_agent`/`wait_agent`).
- **`_common/CLI_COMPATIBILITY.md §4`** — Codex effort-routing note + cross-ref.

## Testing
- [x] Cross-ref grep: all `CODEX_ORCHESTRATION` links resolve; C1–C8 references consistent
- [x] Self-review pass fixed 2 Claude-hub hardcoding inconsistencies (intro line, Plan-and-Execute contract)
- [x] Docs-only change — no executable code, no CI configured in repo
- [x] Backward-compatible: Claude Code hub behavior unchanged (additive only)

## Notes
Grounded only in verified repo facts (`CLI_COMPATIBILITY.md`, Execution Layers, memory). Codex reasoning-effort config key/level names are left marked 未確認 (no speculative completion) — effort is expressed as model choice (`gpt-5.1-codex-max` plan / `gpt-5.1` execute).