### PR TITLE
feat(skills): deepen Rust support in radar and anvil

### DIFF
--- a/anvil/references/cli-design-patterns.md
+++ b/anvil/references/cli-design-patterns.md
@@ -347,6 +347,36 @@ fn init_project(name: Option<String>, template: String, yes: bool) -> Result<()>
 }
 ```
 
+### Rust CLI Specifics (2026)
+
+**Error handling & exit codes** — use `anyhow` in the binary (type-erased, `?`-friendly, prints the context chain); keep typed errors (`thiserror`) only in library crates the CLI depends on. Map error categories to distinct exit codes instead of a blanket `1`, and let `main` return `Result` so the runtime prints the chain:
+
+```rust
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e:#}");          // {:#} prints the full anyhow context chain
+            ExitCode::from(match e.downcast_ref::<CliError>() {
+                Some(CliError::Usage)  => 2,    // bad invocation (mirror clap's exit code)
+                Some(CliError::Config) => 78,   // EX_CONFIG (sysexits.h)
+                _ => 1,
+            })
+        }
+    }
+}
+```
+
+**Async CLIs** — default to `#[tokio::main(flavor = "current_thread")]` for a single-threaded CLI; only opt into the multi-thread runtime when the command does real parallel I/O. The current-thread flavor has lower startup cost and smaller binaries.
+
+**Config precedence** — use `figment` (layered: defaults → file → env → flags) or `confy` (zero-config TOML at the XDG path) instead of hand-rolling merge logic; both deserialize straight into a `serde` struct so validation lives in the type.
+
+**Color & TTY** — honor the `NO_COLOR` env var and `--no-color`, and auto-disable styling when stdout is not a TTY. `owo-colors` with `OwoColorize::if_supports_color` (via `supports-color`) gates styling automatically; `anstream`/`anstyle` (what clap uses) is the lower-level option.
+
+**Binary size** (release profile) — for distributed CLIs, set `lto = true`, `codegen-units = 1`, `panic = "abort"`, `strip = true`, and `opt-level = "z"` in `[profile.release]`; profile the result with `cargo-bloat` before committing to feature-gating.
+
 ### Template Engine Patterns
 
 | Language | Engine | Use Case |

--- a/radar/SKILL.md
+++ b/radar/SKILL.md
@@ -155,7 +155,7 @@ Parse the first token of user input:
 | TypeScript / JavaScript | Vitest 4.x / Jest 30 | v8 / istanbul | RTL, MSW, `vi.fn()` | `references/testing-patterns.md` |
 | Python | pytest 8.x | coverage.py / pytest-cov | pytest-mock, `unittest.mock` | `references/multi-language-testing.md` |
 | Go | `testing` / testify | `go test -cover` | gomock / mockery | `references/multi-language-testing.md` |
-| Rust | `cargo test` / cargo-nextest | tarpaulin / llvm-cov | mockall | `references/multi-language-testing.md` |
+| Rust | `cargo test` / cargo-nextest (+ proptest, insta, criterion; miri/loom for `unsafe`/concurrency) | llvm-cov (default) / tarpaulin | mockall | `references/multi-language-testing.md` |
 | Java | JUnit 5.12+ / JUnit 6 | JaCoCo | Mockito | `references/multi-language-testing.md` |
 
 ## Test Mix

--- a/radar/references/multi-language-testing.md
+++ b/radar/references/multi-language-testing.md
@@ -101,7 +101,7 @@ go test ./... -cover | grep -E "coverage: [0-7][0-9]\\." && exit 1 || echo "OK"
 - Keep unit tests in-module for private behavior and integration tests in `tests/` for public API.
 - Use parameterized tests for edge matrices.
 - Use `tokio::test` for async code.
-- Prefer `cargo-nextest` in CI for faster, isolated test runs (up to 3x faster than `cargo test`; RustRover 2026.1 adds native nextest IDE integration). Source: [nexte.st](https://nexte.st/)
+- Prefer `cargo-nextest` in CI for faster, isolated test runs (up to 3x faster than `cargo test`; per-test process isolation; RustRover 2026.1 adds native nextest IDE integration). Source: [nexte.st](https://nexte.st/)
 - `cargo-mutants` integrates with nextest: `cargo mutants --test-tool nextest` for parallel mutant runs.
 
 ```rust
@@ -113,12 +113,43 @@ fn is_blank_cases(input: &str, expected: bool) {
 }
 ```
 
-Coverage commands:
+### Tooling Selection (2026)
+
+| Concern | Tool | When to reach for it |
+|---------|------|----------------------|
+| Property-based | `proptest` (default) / `quickcheck` | Invariants over a generated input domain. proptest has richer shrinking + a persisted regression corpus (`proptest-regressions/`); quickcheck is lighter for simple `Arbitrary` cases. |
+| Snapshot | `insta` | Lock complex output (serialized structs, rendered text, error chains). `cargo insta review` for the accept/reject workflow; prefer inline snapshots for small values. |
+| Benchmark / perf-regression | `criterion` | Statistical micro-benchmarks with regression detection across runs. Keep in `benches/`, not in the unit suite (don't gate PRs on noisy bench numbers — track trend). |
+| Fuzzing | `cargo-fuzz` (libFuzzer) | Parsers, decoders, untrusted-input boundaries. **Requires nightly, Unix-only** (no Windows). Seed a corpus; distinct from proptest — fuzzing is coverage-guided and unbounded. |
+| UB in `unsafe` | `cargo +nightly miri test` | Any crate with `unsafe`, raw pointers, or FFI. Catches use-after-free, OOB, and invalid-value UB the normal test run cannot. Gate critical `unsafe` modules in a nightly CI job. |
+| Concurrency permutations | `loom` | Lock-free / atomics / hand-rolled synchronization. Exhaustively explores interleavings under `#[cfg(loom)]` — `tokio::test` alone cannot find these races. |
+
+```rust
+// proptest: invariant over a generated domain
+proptest! {
+    #[test]
+    fn roundtrip_encode_decode(s in ".*") {
+        prop_assert_eq!(decode(&encode(&s)), s);
+    }
+}
+
+// insta: snapshot a complex value (review with `cargo insta review`)
+insta::assert_yaml_snapshot!(parse_config(input)?);
+
+// async: tokio::test with explicit flavor + timeout to surface hangs
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fetches_within_budget() {
+    let r = tokio::time::timeout(Duration::from_secs(2), fetch(url)).await;
+    assert!(r.is_ok(), "fetch exceeded budget (possible deadlock)");
+}
+```
+
+Coverage commands — **prefer `cargo-llvm-cov`** (LLVM source-based, the accurate default); `tarpaulin` is faster but ptrace-based and less precise on branch/`async` coverage. Note `llvm-cov` has known limitations on Windows GNU/MSVC targets.
 
 ```bash
-cargo tarpaulin --out html --output-dir coverage/
-cargo llvm-cov --html --output-dir coverage/
-cargo llvm-cov --fail-under-lines 80
+cargo llvm-cov --html --output-dir coverage/   # accurate, source-based (default choice)
+cargo llvm-cov --fail-under-lines 80           # CI gate
+cargo tarpaulin --out html --output-dir coverage/  # faster, lower precision — Linux-first
 ```
 
 ## Java


### PR DESCRIPTION
## Summary
Strengthen Rust coverage in existing skills. Audit found `builder` already comprehensive (3 dedicated Rust references) and current, so changes target the two skills with genuine gaps: `radar` (testing) and `anvil` (CLI).

## Changes
- **radar** (`references/multi-language-testing.md`, `SKILL.md`): add a 2026 Rust testing "Tooling Selection" table — proptest/quickcheck (property), insta (snapshot), criterion (bench), cargo-fuzz (nightly fuzzing), miri (UB in `unsafe`), loom (concurrency). Prefer `cargo-llvm-cov` over tarpaulin for coverage; surface the new tooling in the language matrix.
- **anvil** (`references/cli-design-patterns.md`): add "Rust CLI Specifics (2026)" — anyhow/thiserror split, sysexits exit-code mapping via `ExitCode`, tokio flavor selection, figment/confy config, NO_COLOR/owo-colors styling, release binary-size tuning.

## Risk
Low. Documentation/reference content only — no executable code, no behavior change. All facts source-verified (Edition 2024=1.85, async fn in traits stable 1.75, clap v4, ratatui v0.30, cargo-fuzz nightly/Unix-only).

## Test plan
- [x] Markdown integrity verified
- [x] English-only per SKILL.md language convention
- [x] No fabricated versions/APIs (sourced)