### PR TITLE
refactor(skills): harden improvement & test agent workflows

### DIFF
--- a/bolt/SKILL.md
+++ b/bolt/SKILL.md
@@ -109,10 +109,10 @@ Agent role boundaries → `_common/BOUNDARIES.md`
 
 | Phase | Required action | Key rule | Read |
 |-------|-----------------|----------|------|
-| `PROFILE` | Hunt for performance opportunities (frontend: re-renders, bundle, lazy, virtualization, debounce; backend: N+1, indexes, caching, async, pooling, pagination) | Measure before optimizing | `references/profiling-tools.md` |
-| `SELECT` | Pick ONE improvement: measurable impact, <50 lines, low risk, follows patterns | One at a time | `references/react-performance.md`, `references/database-optimization.md` |
+| `PROFILE` | Hunt for performance opportunities (frontend: re-renders, bundle, lazy, virtualization, debounce; backend: N+1, indexes, caching, async, pooling, pagination) | No captured baseline metric → STOP and profile first; never optimize on assumption | `references/profiling-tools.md` |
+| `SELECT` | Pick ONE improvement: measurable impact, <50 lines, low risk, follows patterns | One at a time; if the bottleneck is the DB query plan hand off to Tuner, not a local fix | `references/react-performance.md`, `references/database-optimization.md` |
 | `OPTIMIZE` | Clean code, comments explaining optimization, preserve functionality, consider edge cases | Readability preserved | Domain-specific reference |
-| `VERIFY` | Run lint+test, measure impact, ensure no regression | Impact documented | `references/profiling-tools.md` |
+| `VERIFY` | Run lint+test, compare after-metric against the captured baseline | Must beat baseline — if it does not, revert and reselect; hand the change to Radar for a perf-regression test | `references/profiling-tools.md` |
 | `PRESENT` | PR title with improvement, body: What/Why/Impact/Measurement | Show the numbers | `references/agent-integrations.md` |
 
 ## Recipes

--- a/radar/SKILL.md
+++ b/radar/SKILL.md
@@ -135,18 +135,19 @@ Single source of truth for Recipe definitions. Behavior depth lives in the Behav
 Parse the first token of user input:
 - If it matches a Recipe Subcommand in the Recipes table → activate that Recipe and load its "Read First" reference.
 - Otherwise → default Recipe (`edge` = Edge Cases).
-- Apply SCAN → LOCK → PING → VERIFY workflow regardless of Recipe.
+- Apply SCAN → LOCK → PING → VERIFY → DELIVER workflow regardless of Recipe.
 
 ## Workflow
 
-`SCAN → LOCK → PING → VERIFY`
+`SCAN → LOCK → PING → VERIFY → DELIVER`
 
 | Phase | Goal | Output | Read |
 |-------|------|--------|------|
-| `SCAN` | Find blind spots, flaky signals, or expensive suites | Candidate list with risk and evidence | `references/` |
-| `LOCK` | Choose the smallest high-value target | Explicit test scope and success condition | `references/` |
-| `PING` | Implement or refine tests | Focused tests using project-native patterns | `references/` |
-| `VERIFY` | Run targeted tests, then broader confirmation | Commands, results, and residual risk | `references/` |
+| `SCAN` | Find blind spots, flaky signals, or expensive suites | Candidate list with risk and evidence; quarantine any test flaking > 10% over 30 days out of the blocking gate (with a root-cause ticket) | `references/coverage-strategy.md`, `references/flaky-test-guide.md` |
+| `LOCK` | Choose the smallest high-value target | Explicit test scope and success condition, ranked by risk × blast-radius × uncovered-branch count | `references/testing-patterns.md` |
+| `PING` | Implement or refine tests | Focused tests using project-native patterns; for regression/bug-repro, confirm the test fails on unpatched code first (fail-first) | `references/multi-language-testing.md` |
+| `VERIFY` | Run targeted tests, then broader confirmation | Commands, results, coverage + mutation delta, zero tautological/assertion-free tests, residual risk | `references/mutation-testing.md` |
+| `DELIVER` | Route results to downstream | Handoff: Guardian (PR), Scout/Builder (fix loop), Sentinel (security regression), Voyager (browser-level escalation) | `references/testing-patterns.md` |
 
 ## Language Support
 

--- a/sentinel/SKILL.md
+++ b/sentinel/SKILL.md
@@ -155,9 +155,9 @@ Agent role boundaries -> `_common/BOUNDARIES.md`
 |-------|-----------------|----------|------|
 | `SCAN` | Hunt for secrets, injections, auth gaps, missing headers, unsafe AI patterns, dependency CVEs, and API misconfigurations | Use delta scanning for new/changed code first | `references/vulnerability-patterns.md` |
 | `PRIORITIZE` | Choose the highest-severity issue that can be resolved safely in `< 50 lines` | Fix CRITICAL before HIGH, HIGH before MEDIUM | `references/owasp-2025-checklist.md` |
-| `FILTER` | Apply confidence scoring, delta scan focus, and framework-aware false-positive suppression | HIGH ≥ 80% include; MEDIUM 50-79% note; LOW < 50% suppress | `references/defensive-controls.md` |
+| `FILTER` | Apply confidence scoring, delta scan focus, and framework-aware false-positive suppression | HIGH ≥ 80% include; MEDIUM 50-79% note; LOW < 50% suppress; ground every shipped finding even on the single-engine path (cited sink reachable, CVE present in lockfile, AI-suggested import exists in registry) before reporting | `references/defensive-controls.md` |
 | `SECURE` | Apply the fix using defensive code, established libraries, `Zod`, `helmet`, strict auth checks, or dependency/CI hardening | Use framework-native controls; prefer established libraries | `references/defensive-controls.md` |
-| `VERIFY` | Run lint/tests, confirm issue is closed, check regressions, keep CSP in report-only where needed | Confirm no regressions introduced | `references/owasp-2025-checklist.md` |
+| `VERIFY` | Re-scan the fixed sink to confirm the vulnerability no longer triggers; run lint/tests and check regressions; keep CSP in report-only where needed | Re-scan confirms closure (not just "looks fixed"); for secrets confirm revocation+rotation, not deletion; request regression coverage from Radar for CRITICAL/HIGH fixes | `references/owasp-2025-checklist.md` |
 | `PRESENT` | Report severity, confidence, OWASP mapping, impact, evidence, remediation, and verification steps | One primary finding or enhancement per invocation | `references/owasp-2025-checklist.md` |
 
 ## Recipes

--- a/tuner/SKILL.md
+++ b/tuner/SKILL.md
@@ -55,14 +55,15 @@ Route elsewhere when the task is primarily:
 
 ## Workflow
 
-`ANALYZE → DIAGNOSE → OPTIMIZE → VALIDATE`
+`ANALYZE → DIAGNOSE → OPTIMIZE → VALIDATE → PRESENT`
 
 | Phase | Focus | Required checks | Read |
 |-------|-------|-----------------|------|
-| `ANALYZE` | Collect evidence | Execution plan, slow-query sample, workload context | `references/explain-analyze-guide.md` |
-| `DIAGNOSE` | Isolate the bottleneck | Root cause, scan/join/sort/index findings | `references/optimization-patterns.md` |
-| `OPTIMIZE` | Choose the safest improvement | Rewrite, index, config, cache, MV, or partition recommendation | `references/materialized-views-partitioning.md` |
-| `VALIDATE` | Prove the change | Before/after plan and measurable impact | `references/slow-query-benchmarks.md` |
+| `ANALYZE` | Collect evidence and lock a baseline | Capture baseline `EXPLAIN (ANALYZE, BUFFERS)`, slow-query sample, and workload context **before any change** — no baseline, no optimization | `references/explain-analyze-guide.md` |
+| `DIAGNOSE` | Isolate the bottleneck | Root cause across scan/join/sort/index; flag version-specific wins (PG18 AIO / skip scan / uuidv7 / virtual generated columns) | `references/optimization-patterns.md` |
+| `OPTIMIZE` | Choose the safest improvement | Rewrite, index, config, cache, MV, or partition recommendation; quantify write-amplification and emit `CONCURRENTLY` DDL + rollback SQL for index/migration changes | `references/materialized-views-partitioning.md` |
+| `VALIDATE` | Prove the change, guard the rest | Side-by-side before/after `EXPLAIN ANALYZE` diff with row-estimate-ratio delta; confirm no plan regression on adjacent reads/writes — revert the recommendation if a secondary query regresses | `references/slow-query-benchmarks.md` |
+| `PRESENT` | Deliver and hand off | Report before/after P50/P95/P99 + buffer hits/reads; route Schema (migration ownership), Bolt (app caching), Beacon (before/after monitoring) | `references/fix-prompt-generation.md` |
 
 ## Core Contract
 
@@ -75,7 +76,7 @@ Route elsewhere when the task is primarily:
 - Verify row estimate accuracy: planner estimate vs. actual ratio > 10× indicates stale statistics or predicate issues; > 100× makes the plan unreliable.
 - Prefer composite indexes over multiple single-column indexes when queries filter on 2+ columns together.
 - On PostgreSQL 18+, recommend `uuidv7()` over `gen_random_uuid()` for indexed primary keys — UUIDv7's time-ordering eliminates B-tree page splits and reduces buffer hits by ~30× compared to random UUIDv4.
-- Author for Opus 4.8 defaults. Apply [\_common/OPUS_48_AUTHORING.md](~/.claude/skills/_common/OPUS_48_AUTHORING.md) principles **P3 (eagerly Read `EXPLAIN (ANALYZE, BUFFERS)` output, schema, indexes, and statistics at PROFILE — optimization recommendations without plan evidence are speculation; distinguish cache hits from disk I/O), P5 (think step-by-step at index read/write trade-offs, row-estimate-ratio diagnosis (>10× stale stats, >100× unreliable), and PostgreSQL version-specific tuning (17 vs 18+, UUIDv7, skip scan))** as critical for Tuner. P2 recommended: calibrated performance report preserving before/after P50/P95/P99, buffer hits/reads, and row-estimate ratios. P1 recommended: front-load DB engine+version, workload class, and latency target at PROFILE.
+- Author for Opus 4.8 defaults. Apply [\_common/OPUS_48_AUTHORING.md](~/.claude/skills/_common/OPUS_48_AUTHORING.md) principles **P3 (eagerly Read `EXPLAIN (ANALYZE, BUFFERS)` output, schema, indexes, and statistics at ANALYZE — optimization recommendations without plan evidence are speculation; distinguish cache hits from disk I/O), P5 (think step-by-step at index read/write trade-offs, row-estimate-ratio diagnosis (>10× stale stats, >100× unreliable), and PostgreSQL version-specific tuning (17 vs 18+, UUIDv7, skip scan))** as critical for Tuner. P2 recommended: calibrated performance report preserving before/after P50/P95/P99, buffer hits/reads, and row-estimate ratios. P1 recommended: front-load DB engine+version, workload class, and latency target at ANALYZE.
 - Pair every actionable performance finding with a paste-ready `## LLM Fix Prompt` block in the report. The prompt embeds the slow query (verbatim), current EXPLAIN ANALYZE plan (highlighting the bottleneck node), predicted plan after fix, workload context (table size, selectivity, buffer hits/reads, row-estimate ratio, frequency, P99), recommended action (with `CREATE INDEX CONCURRENTLY` for production index DDL), acceptance criteria, ruled-out alternatives, and "what NOT to do". Suppress when handing off to Schema (migration ownership) or Bolt (app-level caching), and withhold in analysis-only mode or when the query is owned by a 3rd-party library. See `references/fix-prompt-generation.md` and universal rules in `_common/LLM_PROMPT_GENERATION.md`.
 
 ## Boundaries
@@ -214,7 +215,7 @@ For natural-language input without an explicit subcommand. Subcommand match wins
 Parse the first token of user input:
 - If it matches a Recipe Subcommand in the Recipes table → activate that Recipe; load only the "Read First" file at the initial step.
 - Otherwise, match against **Signal Keywords → Recipe** for natural-language input.
-- Fallback → default Recipe (`explain` = Explain Analyze). Apply standard ANALYZE → DIAGNOSE → OPTIMIZE → VALIDATE workflow.
+- Fallback → default Recipe (`explain` = Explain Analyze). Apply standard ANALYZE → DIAGNOSE → OPTIMIZE → VALIDATE → PRESENT workflow.
 - If the request matches another agent's primary role, route per `_common/BOUNDARIES.md` (Schema for migrations via `TUNER_TO_SCHEMA`, Builder for app rewrites via `TUNER_TO_BUILDER`).
 
 ## Output Requirements
@@ -286,7 +287,7 @@ In all suppression cases, write a one-line note in the report explaining why the
 | [\_common/LLM_PROMPT_GENERATION.md](~/.claude/skills/_common/LLM_PROMPT_GENERATION.md) | You need universal authoring rules, prompt structure, or the cross-agent verb/suppression principles shared with Scout/Trail/Sentinel |
 | [\_common/BOUNDARIES.md](~/.claude/skills/_common/BOUNDARIES.md) | Role boundaries are ambiguous |
 | [\_common/OPERATIONAL.md](~/.claude/skills/_common/OPERATIONAL.md) | You need journal, activity log, AUTORUN, Nexus, Git, or shared operational defaults |
-| [\_common/OPUS_48_AUTHORING.md](~/.claude/skills/_common/OPUS_48_AUTHORING.md) | You are sizing the performance report, deciding adaptive thinking depth at index trade-offs, or front-loading DB engine/version/workload/latency target at PROFILE. Critical for Tuner: P3, P5. |
+| [\_common/OPUS_48_AUTHORING.md](~/.claude/skills/_common/OPUS_48_AUTHORING.md) | You are sizing the performance report, deciding adaptive thinking depth at index trade-offs, or front-loading DB engine/version/workload/latency target at ANALYZE. Critical for Tuner: P3, P5. |
 
 ## Operational
 

--- a/voyager/SKILL.md
+++ b/voyager/SKILL.md
@@ -144,14 +144,15 @@ Agent role boundaries -> `_common/BOUNDARIES.md`
 
 ## Workflow
 
-`PLAN → AUTOMATE → STABILIZE → SCALE`
+`PLAN → AUTOMATE → STABILIZE → SCALE → DELIVER`
 
 | Phase | Focus | Required checks |
 |-------|-------|-----------------|
-| PLAN | Choose framework, scope, and environment | Critical journeys, tags, test-data strategy, environment plan |
-| AUTOMATE | Implement reusable tests | Page Objects, fixtures/helpers, stable selectors, deterministic assertions |
-| STABILIZE | Remove flake and false confidence | Wait strategy, auth reuse, data isolation, retry evidence, console/a11y checks |
+| PLAN | Choose framework, scope, and environment; explore intent (Planner) | Critical journeys, risk tags (`@critical`/`@smoke`/`@regression`), test-data strategy, environment plan, visual-regression tier (pixel / perceptual / Visual AI) |
+| AUTOMATE | Implement reusable tests (Generator) | Page Objects (or Screenplay for complex narrative journeys), fixtures/helpers, stable selectors, deterministic assertions |
+| STABILIZE | Remove flake and false confidence (Healer) | Wait strategy, auth reuse, data isolation, retry evidence; axe-core + IGT — never sign off "a11y covered" from automation alone (57% ceiling); quarantine tests flaking > 10% over 30 days |
 | SCALE | Operationalize in CI/CD | Sharding, artifacts, reports, browser/device matrix, failure diagnostics |
+| DELIVER | Route results and escalate | Coverage/bug reports to downstream (Radar / Judge / Guardian); escalate synthetic-monitoring deployment to Beacon and CI infra changes to Gear |
 
 See `## Reference Map` below for per-phase reading guidance.
 
@@ -207,7 +208,7 @@ Voyager receives test escalations, feature specs, and acceptance criteria from u
 ## Subcommand Dispatch
 Parse the first token of user input.
 - If it matches a Recipe Subcommand above → activate that Recipe; load only the "Read First" column files at the initial step.
-- Otherwise → default Recipe (`playwright` = Playwright Suite). Apply normal PLAN → IMPLEMENT → STABILIZE → INTEGRATE workflow.
+- Otherwise → default Recipe (`playwright` = Playwright Suite). Apply normal PLAN → AUTOMATE → STABILIZE → SCALE → DELIVER workflow.
 
 Behavior notes per Recipe:
 - `playwright`: full Playwright E2E test-suite generation. Apply POM pattern; follow the selector-accessibility-first principle for stable selectors.

--- a/zen/SKILL.md
+++ b/zen/SKILL.md
@@ -131,10 +131,10 @@ Agent role boundaries → `_common/BOUNDARIES.md`
 
 | Phase | Action | Key rule | Read |
 |-------|--------|----------|------|
-| `SURVEY` | Inspect the target, detect smells, measure complexity, confirm tests/coverage | Measure before changing | `references/code-smells-metrics.md` |
+| `SURVEY` | Inspect the target, detect smells, measure complexity, confirm tests/coverage | Capture a behavior baseline before changing — if coverage < 80% on the target, route to Radar for characterization tests first | `references/code-smells-metrics.md` |
 | `PLAN` | Pick one recipe or review depth, confirm scope tier, decide whether to hand off first | One meaningful change per pass | `references/refactoring-recipes.md` |
 | `APPLY` | Do one meaningful behavior-preserving change | Preserve behavior; stay in scope tier | Language-specific reference |
-| `VERIFY` | Re-run tests and compare metrics/baselines | All tests must pass; coverage >= previous | `references/refactoring-anti-patterns.md` |
+| `VERIFY` | Re-run tests, compare metrics/baselines, confirm behavior is unchanged | Identical pass/fail signature and coverage >= previous; any behavior delta → revert and route to Judge | `references/refactoring-anti-patterns.md` |
 | `PRESENT` | Return the required report or handoff | Include scope, verification, and metrics | `references/review-report-templates.md` |
 
 ## Recipes


### PR DESCRIPTION
## Summary
Strengthen the Workflow sections of six improvement/test-type agents for cross-family consistency and rigor. Audit-driven (parallel per-agent diagnosis); only high-value, grounded changes applied. Reference/prose only — no executable behavior change.

## Changes
**Improvement agents** (`bf465e5`):
- zen / bolt / sentinel / tuner: baseline-first gates, before/after + rollback VERIFY rules, regression handoffs wired into phases
- tuner: added `PRESENT` phase (was the only sibling missing a deliver phase); fixed stale `PROFILE` phase-name references

**Test agents** (`3996b0f`):
- radar: per-phase reference files (were bare `references/`), flake-quarantine + fail-first + mutation/tautology gates, added `DELIVER` phase
- voyager: wired Planner/Generator/Healer + axe-core a11y-honesty gate + quarantine into phases, added `DELIVER`, fixed stale `IMPLEMENT/INTEGRATE` dispatch phase names

## Risk
Low. SKILL.md workflow-table edits only. All referenced files verified to exist; phase-sequence enumerations kept consistent across each file.

## Test plan
- [x] All referenced reference files exist
- [x] No stale phase-sequence drift (workflow header / dispatch / table aligned)
- [x] English-only per SKILL.md language convention