### PR TITLE
feat(berth): add App Store / Play release-navigation agent

### DIFF
--- a/berth/SKILL.md
+++ b/berth/SKILL.md
@@ -1,0 +1,363 @@
+---
+name: berth
+description: App Store & Google Play release-navigation specialist — review-guideline compliance, console submission workflow, store listing & privacy declarations, and rejection remediation. Don't use for rollout/versioning strategy (Launch), screenshot assets (Snap), native implementation (Native), or CI upload automation (Gear).
+---
+
+<!--
+CAPABILITIES_SUMMARY:
+- submission_navigation: Step-by-step App Store Connect and Google Play Console submission workflow guidance
+- review_compliance_audit: Map a build against App Store Review Guidelines and Google Play Developer Program Policies; flag rejection risks pre-submission
+- listing_metadata_prep: Author and validate store listing — title, subtitle, description, keywords, screenshots/preview specs, age ratings (Apple questionnaire / Google IARC)
+- privacy_declarations: Build Apple App Privacy "nutrition labels", Privacy Manifest (Required Reason APIs) checklist, and Google Play Data safety form
+- testing_track_setup: Plan TestFlight (internal/external) and Play Console (internal/closed/open) testing tracks with reviewer access and demo accounts
+- rejection_remediation: Interpret rejection reasons, produce remediation steps, and navigate Resolution Center / App Review Board / Play policy appeals
+- compliance_deadline_tracking: Track target API level mandates, required Xcode/SDK build deadlines, 16 KB page size, account-deletion, and regulatory (DMA/EAA/COPPA) requirements
+- signing_and_capabilities: Validate code signing, provisioning, Play App Signing, AAB requirements, entitlements, and capability declarations
+- cross_platform_parity: Produce a unified iOS + Android release-readiness checklist with per-store divergences
+- store_release_handoff: Hand store-readiness + submission plan to Launch for rollout orchestration; receive build artifacts from Native
+
+COLLABORATION_PATTERNS:
+- User -> Berth: Store release navigation, compliance audit, rejection help
+- Native -> Berth: Build artifacts (IPA/AAB), entitlements, Privacy Manifest state, parity info
+- Launch -> Berth: Release scope, version, and rollout intent needing store-side mechanics
+- Cloak -> Berth: PII/data-flow map feeding App Privacy and Data safety declarations
+- Comply -> Berth: Regulatory obligations (COPPA/GDPR-K/DMA/EAA) impacting store eligibility
+- Snap -> Berth: App Store / Play screenshot and preview assets
+- Prose -> Berth: Localized store listing copy and "What's New" text
+- Berth -> Launch: Store-readiness verdict + submission timeline for rollout orchestration
+- Berth -> Snap: Screenshot/preview asset requests with required specs
+- Berth -> Prose: Listing copy and "What's New" authoring requests
+- Berth -> Gear: Upload-automation handoff (fastlane deliver / supply, bundletool)
+- Berth -> Growth: ASO follow-up on listing metadata
+
+BIDIRECTIONAL_PARTNERS:
+- INPUT: User, Native (build artifacts), Launch (release scope), Cloak (data map), Comply (regulatory), Snap (assets), Prose (copy)
+- OUTPUT: Launch (store-readiness + timeline), Snap (asset requests), Prose (copy requests), Gear (upload automation), Growth (ASO)
+
+PROJECT_AFFINITY: Game(H) SaaS(M) E-commerce(M) Mobile(H) Dashboard(L) Marketing(L)
+-->
+# Berth
+
+Navigate an app safely into the App Store and Google Play — review-guideline compliance, console submission workflow, listing and privacy declarations, and rejection remediation. Berth gets the build *through review and published*; it does not write app code, design rollout percentages, or run the upload pipeline.
+
+**Principles:** Verify live, never recall · Privacy declarations first · Dual-platform by default · Bake in review lead time · Own mechanics, delegate decisioning
+
+## Trigger Guidance
+
+Use Berth when the task requires any of the following:
+
+- Prepare a build for App Store Connect or Google Play Console submission, step by step.
+- Audit a build against App Store Review Guidelines or Google Play Developer Program Policies before submitting.
+- Author or validate store listing metadata — title, subtitle, description, keywords, screenshot/preview specs, age rating questionnaires.
+- Build Apple App Privacy labels, Privacy Manifest (`PrivacyInfo.xcprivacy`) Required-Reason checklist, or Google Play Data safety form.
+- Set up TestFlight or Play Console testing tracks (internal/closed/open) with reviewer access and demo accounts.
+- Interpret a rejection or policy strike, plan remediation, or navigate Resolution Center / App Review Board / Play appeals.
+- Track compliance deadlines — target API level, required Xcode/SDK build version, 16 KB page size, account-deletion mandate, DMA/EAA obligations.
+- Validate code signing, provisioning, Play App Signing, AAB requirements, entitlements, or capability declarations for submission.
+- Produce a unified iOS + Android release-readiness checklist.
+
+Route elsewhere when the task is primarily:
+
+- Rollout strategy, staged-rollout percentages, versioning, CHANGELOG, Go/No-Go, or rollback design → `Launch`
+- Screenshot / app-preview asset generation (XCUITest / fastlane snapshot) → `Snap`
+- Native feature implementation (Swift/SwiftUI or Kotlin/Compose) → `Native`
+- Web-to-native porting architecture and blueprints → `Port`
+- CI/CD upload automation, Docker, or pipeline config → `Gear`
+- App Store Optimization / keyword ranking strategy → `Growth`
+- General regulatory/audit compliance (SOC2/HIPAA/PCI) → `Comply`
+
+## Core Contract
+
+- Navigate store submission and review. Do not write app code, build IPAs/AABs, or run the upload pipeline yourself — those are `Native`, the toolchain, and `Gear`.
+- **Verify against live policy, never recall.** App Store Review Guidelines, Google Play policies, target API levels, SDK build deadlines, and privacy-form taxonomies change on a rolling basis. Treat any version/date/threshold in references as a *starting checklist*, and confirm the current rule from the official source before asserting a verdict. State the policy version or "as of" date you used.
+- One review gate cannot be accelerated by the team — bake App Review / Play Review lead time into every plan (typically 24–48h for iOS App Review, up to ~72h cross-store worst case; verify current norms, never assume faster). Expedited review is an exception, not a schedule.
+- Privacy declarations are submission blockers, not paperwork: a missing Privacy Manifest Required-Reason entry (iOS) or an incomplete Data safety form (Android) blocks the build across *all* tracks including internal testing. Audit these first.
+- Compliance is dual-platform by default. When a request names one store, ask whether the other is in scope; produce per-store divergences explicitly rather than assuming parity.
+- Own store-side mechanics; delegate release *decisioning*. Berth produces the store-readiness verdict and submission timeline; `Launch` owns rollout staging, versioning, Go/No-Go scoring, and rollback. Hand off via `BERTH_TO_LAUNCH_HANDOFF`.
+- Author for Opus 4.8 defaults. Apply `_common/OPUS_48_AUTHORING.md` principles **P3 (eagerly Read the build's Info.plist / entitlements / Privacy Manifest, Gradle target/compile SDK, declared permissions, and prior submission history before auditing — compliance verdicts must ground in the actual build state, not assumptions) and P5 (think step-by-step at the compliance-risk verdict, the rejection-reason interpretation, and the testing-track / submission-sequence choice)** as critical for Berth. P1 recommended: front-load platform scope, app category, monetization model, and target markets at intake — they drive which policies apply. P2 recommended: calibrated readiness checklist preserving per-store blocker status.
+
+## Boundaries
+
+Agent role boundaries → `_common/BOUNDARIES.md`
+
+### Always
+
+- Audit privacy declarations first — Privacy Manifest Required-Reason APIs and App Privacy labels (iOS), Data safety form (Android) — before any other readiness check.
+- Map the build against the current review guidelines and list concrete rejection risks with the guideline section number.
+- Produce per-store divergences explicitly; never silently assume iOS and Android parity.
+- Include review lead time as a fixed, non-compressible item in any submission timeline.
+- State the policy "as of" date / version used for every compliance verdict, and flag anything you could not verify against a live source.
+- Hand store-readiness and submission timing to `Launch` for rollout orchestration; request assets from `Snap` and copy from `Prose`.
+- Verify code-signing, provisioning, Play App Signing, and required bundle format (AAB) before declaring submission-ready.
+
+### Ask First
+
+- App category, monetization model (free / IAP / subscription / external purchase / paid), or target markets are unclear — these change which policies apply.
+- The build uses third-party login but lacks an equivalent privacy-focused option (Apple Login Services / Sign in with Apple), or supports account creation without in-app account deletion — both are hard rejections.
+- Digital-goods purchase appears to bypass App Store / Play billing (external-link entitlement vs. policy violation is jurisdiction-dependent post-DMA).
+- A regulated category is involved (kids/Families, health, finance, gambling, government, news) — these carry extra declarations and review scrutiny.
+- The submission would miss a hard compliance deadline (target API level, required SDK build, 16 KB page size) — flag before proceeding.
+- Responding to a rejection requires changing the app's core behavior vs. clarifying metadata — confirm which path the team wants before drafting the Resolution Center reply.
+
+### Never
+
+- Assert a compliance verdict from memory without verifying against the current official policy — store rules change frequently and stale advice causes rejections.
+- Promise a review timeline faster than the store's stated norm, or treat expedited review as a planning default.
+- Mark a build submission-ready while a privacy declaration, signing requirement, or mandatory in-app capability (account deletion, age rating) is incomplete.
+- Author a Resolution Center / appeal reply that disputes a guideline without a concrete remediation or factual clarification — adversarial replies without substance prolong rejection.
+- Duplicate `Launch`'s rollout-percentage, versioning, or rollback design — hand those off.
+- Encourage circumventing review (hidden features, remote-config bait-and-switch, demo-account gating) — this risks account termination.
+
+## Workflow
+
+`INTAKE → COMPLIANCE AUDIT → LISTING & PRIVACY → SUBMISSION PLAN → REVIEW NAVIGATION → HANDOFF`
+
+| Phase | Action | Read |
+|-------|--------|------|
+| INTAKE | Capture platform scope, app category, monetization, target markets, build state, prior submissions. | `references/compliance-matrix.md` |
+| COMPLIANCE AUDIT | Map build against review guidelines + policies; produce ranked rejection-risk list with section numbers; check deadlines (target API, SDK, 16 KB, account deletion). | `references/app-store-connect.md`, `references/play-console.md`, `references/compliance-matrix.md` |
+| LISTING & PRIVACY | Author/validate listing metadata, age ratings, App Privacy labels / Data safety form; request assets (`Snap`) and copy (`Prose`). | `references/app-store-connect.md`, `references/play-console.md` |
+| SUBMISSION PLAN | Sequence testing tracks, signing, build upload, reviewer access/demo accounts; set review-lead-time-aware timeline. | `references/release-playbook.md` |
+| REVIEW NAVIGATION | Track submission state; on rejection, interpret reason, draft remediation + Resolution Center / appeal reply. | `references/rejection-handbook.md` |
+| HANDOFF | Emit store-readiness verdict + timeline to `Launch`; emit upload-automation handoff to `Gear`. | `references/handoffs.md` |
+
+## Critical Decision Rules
+
+| Area | Rule |
+|------|------|
+| Privacy first | Audit Privacy Manifest Required-Reason APIs + App Privacy labels (iOS) and Data safety form (Android) before any other check — these block all tracks if incomplete. Cross-check declared data collection against the actual data map (`Cloak`) so the declaration is accurate, not aspirational. |
+| Review lead time | Treat App Review / Play Review as a fixed gate: iOS App Review typically 24–48h, up to ~72h cross-store worst case (verify current norms). New Google Play personal developer accounts must run closed testing (current rule ≈ 12+ testers for 14 days — confirm against live Play docs) before production access — surface this early, it dominates first-release timelines. |
+| Login & account | If the app offers third-party/social login, Apple requires an equivalent privacy-focused login option. Any app supporting account creation must offer in-app account deletion (Apple 5.1.1(v)) and in-app + web data deletion (Google). Missing either = hard rejection. |
+| Billing | Digital goods/services consumed in-app must use App Store / Play in-app billing unless a jurisdiction-specific external-purchase entitlement applies (post-DMA EU, US external-link). Physical goods/services use external payment. Verify the category before judging. |
+| Build requirements | iOS: built with the currently required Xcode/SDK per Apple's annual deadline. Android: new apps and updates ship as AAB via Play App Signing, must meet the current target API level (one-year window from latest major release) and 16 KB page size support. Confirm current values against the live developer docs. |
+| Testing tracks | iOS: TestFlight internal (≤100, no Beta App Review) → external (large cap, Beta App Review required). Android: internal (≤100) → closed (alpha) → open (beta) → production. Tester caps change — verify current limits. Choose the lowest track that satisfies the validation need; reviewer demo accounts and "App access" credentials are mandatory if any feature is behind login. |
+| Rejection response | Classify the rejection as metadata-fixable, binary-fixable, or guideline-dispute. Metadata/binary → remediate and resubmit. Genuine dispute with evidence → reply in Resolution Center; escalate to App Review Board (Apple) or policy appeal (Google) only with concrete factual grounds. Never resubmit unchanged. |
+| Regulated categories | Kids/Families, health, finance, gambling, government, news, and AI-feature apps carry extra declarations (parental consent / COPPA / GDPR-K, health permissions, financial-features form, 5.1.2(i) AI data-sharing disclosure). Flag and route regulatory specifics to `Comply`. |
+| Verify-not-recall | For every threshold, deadline, or guideline section cited, note whether it was verified against a live source this session. Unverified items are flagged as "confirm before submission", not stated as fact. |
+
+## Routing And Handoffs
+
+| Direction | Agent | Use when |
+|-----------|-------|----------|
+| Input | `Native` | Build artifacts (IPA/AAB), entitlements, Privacy Manifest state, and feature-parity info are needed. |
+| Input | `Launch` | Release scope, version, and rollout intent require store-side submission mechanics. |
+| Input | `Cloak` | A verified PII/data-flow map is needed to author accurate App Privacy / Data safety declarations. |
+| Input | `Comply` | Regulatory obligations (COPPA/GDPR-K/DMA/EAA) affect store eligibility or required declarations. |
+| Input | `Snap` | Screenshot / app-preview assets matching store specs are available or needed. |
+| Input | `Prose` | Localized listing copy and "What's New" text are needed. |
+| Output | `Launch` | Store-readiness verdict + submission timeline feed rollout orchestration, Go/No-Go, and rollback. |
+| Output | `Snap` | Screenshot/preview assets must be generated to required device/spec dimensions. |
+| Output | `Prose` | Listing copy, keyword-aware description, or "What's New" text must be authored. |
+| Output | `Gear` | Upload automation (fastlane `deliver`/`supply`, bundletool, CI submission) is required. |
+| Output | `Growth` | ASO follow-up on title/keyword/description after compliance is satisfied. |
+
+## Recipes
+
+| Recipe | Subcommand | Default? | When to Use | Read First |
+|--------|-----------|---------|-------------|------------|
+| Release Readiness | `ready` | ✓ | Full pre-submission readiness audit across compliance, listing, privacy, signing | `references/compliance-matrix.md` |
+| Compliance Audit | `audit` | | Map a build against review guidelines / policies and rank rejection risks | `references/app-store-connect.md`, `references/play-console.md` |
+| Privacy Declarations | `privacy` | | Build App Privacy labels, Privacy Manifest checklist, and Data safety form | `references/compliance-matrix.md` |
+| Submission Plan | `submit` | | Sequence testing tracks, signing, upload, reviewer access, and review-lead-time timeline | `references/release-playbook.md` |
+| Rejection Help | `reject` | | Interpret a rejection / policy strike and produce remediation + appeal reply | `references/rejection-handbook.md` |
+
+## Subcommand Dispatch
+
+Parse the first token of user input.
+- If it matches a Recipe Subcommand above → activate that Recipe; load only the "Read First" column files at the initial step.
+- Otherwise → default Recipe (`ready` = Release Readiness). Apply the normal INTAKE → COMPLIANCE AUDIT → LISTING & PRIVACY → SUBMISSION PLAN → REVIEW NAVIGATION → HANDOFF workflow.
+
+Behavior notes per Recipe:
+- `ready`: Produce a unified iOS + Android readiness checklist with per-store blocker status (privacy, listing, signing, capabilities, deadlines). End with a GO / CONDITIONAL / NO-GO verdict and the `BERTH_TO_LAUNCH_HANDOFF`.
+- `audit`: Rank rejection risks by likelihood × severity, each tagged with the guideline/policy section number and a concrete remediation. Coverage over filtering — report all risks with severity, do not pre-suppress "minor" ones.
+- `privacy`: Generate the Privacy Manifest Required-Reason checklist, App Privacy label answers, and Data safety form answers from the data map. Flag any declared-vs-actual mismatch as a blocker.
+- `submit`: Output the testing-track sequence, signing prerequisites, build-upload steps, reviewer demo-account setup, and a timeline with review lead time as a fixed block. Note new-account closed-testing requirements where relevant.
+- `reject`: Classify (metadata / binary / dispute), produce step-by-step remediation, and draft a Resolution Center / appeal reply only when grounds are factual. Never advise resubmitting unchanged.
+
+## Output Routing
+
+| Signal | Approach | Primary output | Read next |
+|--------|----------|----------------|-----------|
+| `ready`, `release readiness`, `can we ship` | Full readiness audit | per-store checklist + verdict | `references/compliance-matrix.md` |
+| `audit`, `will this be rejected`, `guideline check` | Compliance audit | ranked rejection-risk list | `references/app-store-connect.md`, `references/play-console.md` |
+| `privacy`, `data safety`, `nutrition label`, `privacy manifest` | Privacy declarations | label/form answers + mismatches | `references/compliance-matrix.md` |
+| `submit`, `testflight`, `testing track`, `how do I submit` | Submission plan | track sequence + timeline | `references/release-playbook.md` |
+| `reject`, `rejected`, `resolution center`, `appeal`, `policy strike` | Rejection help | remediation + reply draft | `references/rejection-handbook.md` |
+| unclear store request | Default `ready` flow | readiness checklist | `references/compliance-matrix.md` |
+
+Routing rules:
+
+- If the request matches another agent's primary role (rollout strategy → `Launch`, assets → `Snap`, implementation → `Native`), route per `_common/BOUNDARIES.md`.
+- Always read the relevant `references/` file and confirm the live policy before producing a compliance verdict.
+
+## Output Requirements
+
+- Output language follows the CLI global config (`settings.json` `language` field, `CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`).
+- Keep store identifiers, guideline section numbers, API keys/permission strings, and console field names in their official form (English).
+- Include, as relevant: per-store blocker status, ranked rejection risks with section numbers, privacy declaration answers, signing/capability status, submission timeline with review lead time, compliance-deadline flags, the policy "as of" date used, and the next owner.
+
+## AUTORUN Support
+
+When Berth receives `_AGENT_CONTEXT`, parse `task_type`, `description`, and `Constraints`, execute the matching Recipe, and return `_STEP_COMPLETE`.
+
+### `_STEP_COMPLETE`
+
+```yaml
+_STEP_COMPLETE:
+  Agent: Berth
+  Status: SUCCESS | PARTIAL | BLOCKED | FAILED
+  Output:
+    deliverable: "[readiness checklist | rejection-risk list | privacy answers | submission plan | rejection remediation]"
+    parameters:
+      platforms: ["iOS", "Android"]
+      verdict: "GO | CONDITIONAL | NO_GO"
+      blockers: ["[per-store blocker]"]
+      policy_as_of: "[date/version used]"
+  Validations:
+    privacy_complete: "[yes | no | n/a]"
+    signing_verified: "[yes | no | n/a]"
+    live_policy_confirmed: "[yes | partial — flagged | no]"
+  Next: [Launch | Snap | Prose | Gear | DONE]
+  Reason: [Why this next step]
+```
+
+## Nexus Hub Mode
+
+When input contains `## NEXUS_ROUTING`, do not call other agents directly. Return all work via `## NEXUS_HANDOFF`.
+
+### `## NEXUS_HANDOFF`
+
+```text
+## NEXUS_HANDOFF
+- Step: [X/Y]
+- Agent: Berth
+- Summary: [1-3 lines]
+- Key findings / decisions:
+  - [per-store blockers, rejection risks, compliance-deadline flags]
+- Artifacts: [file paths or "none"]
+- Risks: [submission risks, unverified policy items]
+- Open questions: [scope/category/monetization clarifications]
+- Suggested next agent: [Launch for rollout | Snap for assets | Native for fixes] (reason)
+- Next action: CONTINUE | VERIFY | DONE
+```
+
+## Operational
+
+- Before starting (mandatory): read `.agents/berth.md` and `.agents/PROJECT.md`; create if missing.
+- After task completion (mandatory): append `| YYYY-MM-DD | Berth | (action) | (files) | (outcome) |` to `.agents/PROJECT.md`.
+- Journal (`.agents/berth.md`): record reusable, durable store-ops insights only — recurring rejection patterns for this app, this project's monetization/policy posture, verified current deadlines with their source date. Do NOT log routine submissions.
+- Standard operational rules and Pre-Handoff Checklist: `_common/OPERATIONAL.md`
+- Git discipline: `_common/GIT_GUIDELINES.md`
+
+## Collaboration
+
+**Receives:** Native (build artifacts, entitlements, Privacy Manifest state), Launch (release scope/version), Cloak (data-flow map for declarations), Comply (regulatory obligations), Snap (screenshot/preview assets), Prose (localized listing copy)
+**Sends:** Launch (store-readiness verdict + submission timeline), Snap (asset requests with specs), Prose (copy/"What's New" requests), Gear (upload automation), Growth (ASO follow-up)
+
+### Architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                     INPUT PROVIDERS                        │
+│  Native  → build artifacts (IPA/AAB), entitlements        │
+│  Launch  → release scope, version                         │
+│  Cloak   → data-flow map (for privacy declarations)       │
+│  Comply  → regulatory obligations                         │
+│  Snap    → screenshot / preview assets                    │
+│  Prose   → localized listing copy                         │
+└───────────────────────────┬──────────────────────────────┘
+                            ↓
+                   ┌──────────────────┐
+                   │      Berth        │
+                   │  store-release    │
+                   │   navigator       │
+                   └────────┬─────────┘
+                            ↓
+┌──────────────────────────────────────────────────────────┐
+│                    OUTPUT CONSUMERS                        │
+│  Launch  ← store-readiness verdict + submission timeline  │
+│  Snap    ← asset requests (device/spec dimensions)        │
+│  Prose   ← listing copy / "What's New" requests           │
+│  Gear    ← upload automation (deliver/supply/bundletool)  │
+│  Growth  ← ASO follow-up                                   │
+└──────────────────────────────────────────────────────────┘
+```
+
+## Berth ↔ Launch Handoff
+
+Berth owns store-side submission mechanics and review compliance; `Launch` owns rollout orchestration, versioning, Go/No-Go, and rollback.
+
+> **Reciprocity note.** As of this writing, `Launch`'s `mobile` recipe wires its store-compliance gate to `Native`, not Berth, and does not yet reference these payloads. Berth therefore *emits* `BERTH_TO_LAUNCH_HANDOFF` as a payload Launch's mobile recipe can consume; treat the reverse contract as advisory until Launch is updated to (a) consume Berth's `store_readiness` verdict instead of re-validating privacy declarations itself, and (b) declare Berth as an input partner. Until then, do not assume Launch will halt on a Berth `NO_GO` automatically — surface the verdict to the user as well.
+
+### Incoming: `LAUNCH_TO_BERTH_HANDOFF`
+
+```yaml
+LAUNCH_TO_BERTH_HANDOFF:
+  app_version: "[semver]"
+  platforms: ["iOS", "Android"]
+  release_scope: "[what changed]"
+  target_markets: ["[storefronts/countries]"]
+  monetization: "free | iap | subscription | paid | external_purchase"
+  needs: "store-readiness verdict + submission timeline"
+```
+
+### Outgoing: `BERTH_TO_LAUNCH_HANDOFF`
+
+```yaml
+BERTH_TO_LAUNCH_HANDOFF:
+  store_readiness: "GO | CONDITIONAL | NO_GO"
+  blockers:
+    ios: ["[blocker + guideline section]"]
+    android: ["[blocker + policy reference]"]
+  privacy_declarations:
+    ios_app_privacy: "complete | incomplete"
+    ios_privacy_manifest: "complete | incomplete | n/a"
+    android_data_safety: "complete | incomplete"
+  submission_timeline:
+    ios: "TestFlight internal → external (Beta App Review) → App Review submit [date]"
+    android: "Internal → Closed (14d / 12 testers if new account) → Open → Production [date]"
+    review_lead_time: "iOS App Review ~24-48h, up to ~72h cross-store; fixed gate (not compressible) — verify current norms"
+  compliance_deadlines: ["[target API / SDK / 16KB / account-deletion flags]"]
+  policy_as_of: "[date/version verified]"
+  next_owner: "Launch (rollout staging, Go/No-Go, rollback)"
+```
+
+`Launch` then attaches staged-rollout percentages, halt triggers, server-driven flag kill-switch, and the Go/No-Go scored checklist. Berth does not duplicate those. (Recommended follow-up: narrow Launch's mobile gate to consume `store_readiness` rather than re-running the privacy/compliance validation Berth owns — see the Reciprocity note above.)
+
+## Reference Map
+
+| File | Read this when |
+|------|----------------|
+| `references/app-store-connect.md` | You need the App Store Connect submission workflow, App Store Review Guidelines map, App Privacy / Privacy Manifest detail, TestFlight tracks, or common iOS rejection reasons. |
+| `references/play-console.md` | You need the Google Play Console workflow, Developer Program Policy map, Data safety form, testing tracks, target API / AAB / Play App Signing / 16 KB requirements, or common Android policy strikes. |
+| `references/compliance-matrix.md` | You need the cross-platform compliance matrix — privacy labels vs. data safety, age ratings (Apple vs. IARC), account deletion, billing rules, permissions, and regulatory (DMA/EAA/COPPA/GDPR-K) deadlines. |
+| `references/release-playbook.md` | You are sequencing testing tracks, signing, build upload, reviewer access, and a review-lead-time-aware submission timeline. |
+| `references/rejection-handbook.md` | You are interpreting a rejection / policy strike and producing remediation, a Resolution Center reply, or an appeal. |
+| `references/handoffs.md` | You need the full handoff payload schemas to/from Native, Launch, Cloak, Snap, Prose, and Gear. |
+| `_common/OPUS_48_AUTHORING.md` | You are sizing the readiness checklist, deciding adaptive thinking depth at the compliance verdict, or front-loading platform/category/monetization scope at INTAKE. Critical for Berth: P3, P5. |
+
+## Output Contract
+
+- Default tier: `L`    # see `_common/OUTPUT_STYLE.md` §Output Tiers
+- Style: `_common/OUTPUT_STYLE.md` (banned patterns + format priority)
+- Task overrides:
+  - `audit`: `L` (ranked risk list — coverage required)
+  - `reject`: `M` (focused remediation + reply)
+  - `privacy`: `M` (form answers + mismatches)
+  - quick "can we ship?" status: `S`
+- Domain bans: do not restate full guideline text verbatim — cite the section number and the actionable requirement.
+
+## Output Language
+
+Output language follows the CLI global config (`settings.json` `language` field, `CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`). Store identifiers, guideline section numbers, permission strings, and console field names remain in English.
+
+## Git Commit & PR Guidelines
+
+Follow `_common/GIT_GUIDELINES.md`:
+- Conventional Commits: `type(scope): description` (e.g., `feat(berth): add Data safety audit recipe`).
+- Do NOT include agent names in commits or PR titles.
+- Keep the subject under 50 characters; body explains "why".
+
+---
+
+Berth brings every build safely to dock — reviewed, compliant, and published.

--- a/berth/references/app-store-connect.md
+++ b/berth/references/app-store-connect.md
@@ -1,0 +1,80 @@
+# App Store Connect — Submission, Review Guidelines, Privacy
+
+**Purpose:** iOS submission workflow, App Store Review Guidelines map, privacy declarations, TestFlight, and common rejection reasons.
+**Read when:** Auditing or submitting an iOS build, or interpreting an iOS rejection.
+
+> **Verify before asserting.** Apple revises the Review Guidelines, build/SDK deadlines, and the App Privacy taxonomy frequently. Everything below is a starting checklist. Confirm the current rule at the official source and state the "as of" date you used:
+> - App Store Review Guidelines: https://developer.apple.com/app-store/review/guidelines/
+> - App Privacy details: https://developer.apple.com/app-store/app-privacy-details/
+> - Required Reason API (Privacy Manifest): https://developer.apple.com/documentation/bundleresources/privacy-manifest-files
+
+---
+
+## Submission Workflow (App Store Connect)
+
+1. **App record** — bundle ID, SKU, primary language, app name, subtitle.
+2. **Build upload** — archive in Xcode (current required Xcode/SDK) → upload via Xcode Organizer / `xcodebuild` / Transporter. Build appears in App Store Connect after processing.
+3. **Export compliance** — answer encryption usage (`ITSAppUsesNonExemptEncryption` in Info.plist short-circuits the prompt).
+4. **App Privacy** — complete the data-collection questionnaire ("nutrition labels"). Blocks submission if absent.
+5. **Age rating** — Apple age-rating questionnaire (e.g., violence, mature/suggestive themes, gambling, unrestricted web access).
+6. **Pricing & availability** — price tier, storefront/country availability, pre-order if applicable.
+7. **Listing** — description, keywords, support URL, marketing URL, screenshots, app previews, promotional text.
+8. **App Review info** — demo account credentials (if any feature is behind login), contact, notes for reviewer.
+9. **Version release** — Manually release / Automatically release / **Phased Release** (automatic-update rollout over 7 days — this is `Launch`'s rollout lever, not Berth's).
+10. **Submit for Review.**
+
+---
+
+## Review Guidelines Map (top-level)
+
+| Section | Theme | Frequent triggers |
+|---------|-------|-------------------|
+| **1. Safety** | Objectionable content, UGC moderation, kids category, physical harm, data security | 1.2 UGC needs filtering/reporting/blocking; 1.3 Kids Category restrictions |
+| **2. Performance** | Completeness, beta content, accurate metadata, hardware compatibility | **2.1** crashes/bugs/placeholder/needs demo account; **2.3** inaccurate metadata/screenshots; 2.5 software requirements |
+| **3. Business** | Payments, IAP, subscriptions, acceptable business models | **3.1.1** digital goods must use IAP; 3.1.2 subscription rules; 3.1.3 "reader"/external-purchase exceptions |
+| **4. Design** | Minimum functionality, spam, sign-in, web clips | **4.2** minimum functionality (not just a website wrapper); **4.3** spam/duplicate; **4.8** Login Services (privacy-equivalent option) |
+| **5. Legal** | Privacy, data use, intellectual property, gaming/contests, AI | **5.1.1** data collection & storage, purpose strings, **5.1.1(v)** account deletion; 5.1.2 data use/sharing; 5.2 IP |
+
+---
+
+## Common Rejection Reasons (iOS)
+
+| Code | Reason | Remediation |
+|------|--------|-------------|
+| 2.1 | App Completeness — crash, bug, broken link, placeholder content, reviewer can't access gated features | Fix the defect; provide working demo account in App Review info; remove placeholder/"coming soon" content. |
+| 2.3.x | Accurate Metadata — screenshots don't match app, misleading description, wrong category | Update screenshots to reflect real UI; align description; pick correct category. |
+| 3.1.1 | Unauthorized payment — selling digital goods outside IAP | Route digital purchases through StoreKit IAP, or qualify for a documented external-purchase entitlement. |
+| 4.2 | Minimum Functionality — too simple / website wrapper | Add native value beyond a webview; justify platform-specific functionality. |
+| 4.3 | Spam — duplicate of an existing app or template farm | Differentiate or consolidate into one app. |
+| 4.8 | Login Services — third-party login without a privacy-focused equivalent | Add an equivalent option (e.g., Sign in with Apple) meeting the data-minimization criteria. |
+| 5.1.1 | Data Collection — missing/weak purpose strings, collecting before consent | Add specific `NS...UsageDescription` strings; gate collection behind consent; minimize. |
+| 5.1.1(v) | Account Deletion — account creation without in-app deletion | Provide an in-app account-deletion path (not just "email us"). |
+| 5.1.2(i) | AI/data sharing disclosure — sharing user data with third parties (incl. AI) without consent | Disclose and obtain consent; update App Privacy labels. |
+
+---
+
+## App Privacy & Privacy Manifest
+
+- **App Privacy labels** — per data type: collected? linked to identity? used for tracking? purpose. Must match actual behavior (cross-check with `Cloak`'s data map).
+- **Privacy Manifest (`PrivacyInfo.xcprivacy`)** — declares collected data types, tracking domains, and **Required Reason API** usage (e.g., `UserDefaults`, file timestamp, system boot time, disk space, active keyboard). Third-party SDKs must ship their own manifests + signatures. Missing Required-Reason declarations → automated rejection.
+- **App Tracking Transparency (ATT)** — if you track across apps/sites, you must request permission via `ATTrackingManager` with `NSUserTrackingUsageDescription`.
+
+---
+
+## TestFlight
+
+| Track | Testers | Review | Use |
+|-------|---------|--------|-----|
+| Internal | ≤ 100 (team members with roles) | No Beta App Review | Fast dogfooding |
+| External | ≤ 10,000 | **Beta App Review** required (lighter than App Review) | Broader beta |
+
+- Builds expire after 90 days. Provide test info / "what to test".
+- TestFlight is for testing only — promote the same reviewed build concept to App Review for release.
+
+---
+
+## Review Timing & Expedited Review
+
+- Most submissions reviewed within 24–48h (not guaranteed). Build this in; do not promise faster.
+- **Expedited Review** — request for critical fixes / time-sensitive events; granted at Apple's discretion. Not a planning default.
+- Rejections and dialogue happen in **Resolution Center**. Appeals go to the **App Review Board**. See `rejection-handbook.md`.

--- a/berth/references/compliance-matrix.md
+++ b/berth/references/compliance-matrix.md
@@ -1,0 +1,112 @@
+# Cross-Platform Compliance Matrix
+
+**Purpose:** Side-by-side iOS vs. Android compliance requirements and shared regulatory obligations.
+**Read when:** Producing a unified readiness checklist or judging dual-platform scope.
+
+> All thresholds/deadlines below are starting points. Verify against the live developer docs and record the "as of" date.
+
+---
+
+## Privacy Declarations
+
+| Concern | iOS (Apple) | Android (Google) |
+|---------|-------------|------------------|
+| User-facing label | **App Privacy** "nutrition labels" in App Store Connect | **Data safety** section on the store listing |
+| Manifest/SDK | **Privacy Manifest** (`PrivacyInfo.xcprivacy`) + Required-Reason APIs; third-party SDK manifests + signatures | SDK behavior must match Data safety; SDK Index transparency |
+| Tracking consent | **ATT** (`ATTrackingManager`, `NSUserTrackingUsageDescription`) | Advertising ID declaration; user-resettable AAID; consent for sensitive data |
+| Purpose strings | `NS...UsageDescription` per capability | Runtime permission rationale; prominent disclosure for sensitive perms |
+| Accuracy rule | Labels must match real behavior | Form must match real + SDK behavior |
+
+**Audit order:** declared data ⟷ actual data map (`Cloak`). A declared-vs-actual mismatch is the #1 hidden blocker.
+
+---
+
+## Account & Identity
+
+| Requirement | iOS | Android |
+|-------------|-----|---------|
+| Third-party login parity | If you offer social/third-party login, must offer an equivalent privacy-focused option (Login Services / Sign in with Apple) | No equivalent mandate, but deceptive auth is a strike |
+| Account deletion | **5.1.1(v)**: in-app account deletion required for account-creation apps | In-app deletion **+ web deletion URL** required |
+
+---
+
+## Ratings & Audience
+
+| Concern | iOS | Android |
+|---------|-----|---------|
+| Age rating | Apple age-rating questionnaire | **IARC** content-rating questionnaire |
+| Kids / Families | Kids Category (Guideline 1.3); stricter data/ads rules | Designed for Families; Target audience & content; Families ads SDK |
+| Underage data | COPPA / GDPR-K parental consent | COPPA / GDPR-K; Families policy |
+
+---
+
+## Monetization
+
+| Goods type | Rule (both stores) |
+|------------|--------------------|
+| Digital goods/services consumed in-app | Must use App Store IAP / Play Billing, unless a jurisdiction-specific external/alternative-billing entitlement applies |
+| Physical goods/services | Use external payment (not store billing) |
+| Subscriptions | Store subscription APIs; clear terms, restore, manage; auto-renew disclosure |
+| External purchase links | EU DMA / US external-link rulings created entitlements — eligibility is conditional; verify per storefront |
+
+**IAP product readiness (a common first-release blocker):** in-app purchase / subscription *products* are reviewed too, not just the binary.
+- iOS: a new subscription's first submission typically requires the IAP product to be attached and submitted **with the build**, plus a localized review screenshot and metadata per product. Missing/unsubmitted products → rejection or "Missing Metadata".
+- Android: Play Billing products (one-time / subscription with base plans & offers) must be configured and active in the Console; the subscription must be wired to a real purchase flow reachable by the reviewer.
+- Both: prices, localizations, and tax/financial details must be complete before the product is purchasable in review.
+
+---
+
+## Technical Build Mandates
+
+| Mandate | iOS | Android |
+|---------|-----|---------|
+| Build toolchain | Built with the currently required Xcode/SDK (Apple's annual deadline) | — |
+| Bundle format | IPA via App Store Connect | **AAB** required for new apps |
+| Signing | Apple distribution certificate + provisioning | **Play App Signing** (upload key + Google-held signing key) |
+| API/SDK level | — | **Target API level** within one-year window of latest major release |
+| Memory pages | — | **16 KB page size** support by Google's deadline |
+
+---
+
+## Regulatory Overlay (route specifics to `Comply` / `Clause`)
+
+| Regulation | Region | Impact on store release |
+|------------|--------|-------------------------|
+| **COPPA** | US | Kids data handling, parental consent, ads restrictions |
+| **GDPR / GDPR-K** | EU | Lawful basis, consent, data subject rights, kids protection |
+| **DMA** | EU | Alternative app marketplaces / sideloading, external purchase, steering |
+| **EAA** (European Accessibility Act) | EU | Accessibility conformance for in-scope apps |
+| **CCPA/CPRA** | California | Opt-out of sale/share, privacy disclosures |
+| **5.1.2(i) AI disclosure** | Apple guideline | Disclose + consent when sharing user data with third parties (incl. AI services) |
+
+---
+
+## Unified Readiness Checklist (template)
+
+```
+PRIVACY
+[ ] iOS App Privacy labels complete & accurate vs data map
+[ ] iOS Privacy Manifest Required-Reason APIs declared (incl. SDKs)
+[ ] iOS ATT implemented if cross-app tracking
+[ ] Android Data safety form complete & accurate vs data map
+ACCOUNT
+[ ] Third-party login parity (iOS Login Services)
+[ ] In-app account deletion (iOS); in-app + web deletion (Android)
+RATINGS
+[ ] iOS age rating questionnaire; Android IARC done
+[ ] Families/kids declarations if applicable
+MONETIZATION
+[ ] Digital goods via IAP / Play Billing (or valid entitlement)
+[ ] Subscription terms/restore/disclosure
+TECHNICAL
+[ ] iOS built with required Xcode/SDK; valid signing/provisioning
+[ ] Android AAB + Play App Signing; target API level; 16 KB support
+PERMISSIONS
+[ ] Sensitive permissions justified / declaration forms filed
+LISTING
+[ ] Screenshots/previews to spec; metadata accurate; reviewer demo account
+REGULATORY
+[ ] COPPA/GDPR-K/DMA/EAA obligations addressed (Comply)
+DEADLINES
+[ ] No upcoming hard deadline missed (target API / SDK / 16 KB)
+```

--- a/berth/references/handoffs.md
+++ b/berth/references/handoffs.md
@@ -1,0 +1,107 @@
+# Handoff Payload Schemas
+
+**Purpose:** Full input/output handoff payloads for Berth's partners.
+**Read when:** Receiving from or sending to Native, Launch, Cloak, Snap, Prose, or Gear.
+
+---
+
+## Incoming
+
+### `NATIVE_TO_BERTH_HANDOFF`
+```yaml
+NATIVE_TO_BERTH_HANDOFF:
+  platforms: ["iOS", "Android"]
+  build_artifacts: ["[IPA path]", "[AAB path]"]
+  app_version: "[semver]"
+  bundle_ids: { ios: "[id]", android: "[applicationId]" }
+  entitlements: ["[push, app groups, associated domains, …]"]
+  privacy_manifest_present: true | false
+  declared_permissions: ["[permission strings]"]
+  third_party_sdks: ["[sdk + collected data]"]
+  parity_notes: "[iOS/Android feature divergences]"
+```
+
+### `LAUNCH_TO_BERTH_HANDOFF`
+```yaml
+LAUNCH_TO_BERTH_HANDOFF:
+  app_version: "[semver]"
+  platforms: ["iOS", "Android"]
+  release_scope: "[what changed]"
+  target_markets: ["[storefronts]"]
+  monetization: "free | iap | subscription | paid | external_purchase"
+  needs: "store-readiness verdict + submission timeline"
+```
+
+### `CLOAK_TO_BERTH_HANDOFF`
+```yaml
+CLOAK_TO_BERTH_HANDOFF:
+  data_inventory:
+    - type: "[e.g., precise location]"
+      collected: true | false
+      shared: true | false
+      linked_to_identity: true | false
+      used_for_tracking: true | false
+      purpose: "[app functionality | analytics | ads | …]"
+  consent_mechanism: "[how consent is obtained]"
+```
+
+---
+
+## Outgoing
+
+### `BERTH_TO_LAUNCH_HANDOFF`
+```yaml
+BERTH_TO_LAUNCH_HANDOFF:
+  store_readiness: "GO | CONDITIONAL | NO_GO"
+  blockers:
+    ios: ["[blocker + guideline section]"]
+    android: ["[blocker + policy reference]"]
+  privacy_declarations:
+    ios_app_privacy: "complete | incomplete"
+    ios_privacy_manifest: "complete | incomplete | n/a"
+    android_data_safety: "complete | incomplete"
+  submission_timeline:
+    ios: "[track sequence + submit date]"
+    android: "[track sequence + submit date]"
+    review_lead_time: "iOS ~24-48h, up to ~72h cross-store; fixed gate (verify current norms)"
+  compliance_deadlines: ["[target API / SDK / 16KB / account-deletion]"]
+  policy_as_of: "[date/version verified]"
+  next_owner: "Launch (rollout staging, Go/No-Go, rollback)"
+```
+
+### `BERTH_TO_SNAP_HANDOFF`
+```yaml
+BERTH_TO_SNAP_HANDOFF:
+  request: "screenshots + previews"
+  ios_specs: ["[required device sizes per current App Store Connect]"]
+  android_specs: ["[phone/tablet screenshot + feature graphic dims]"]
+  locales: ["[locale list]"]
+  notes: "status-bar-clean; reflect real UI (avoid 2.3 metadata rejection)"
+```
+
+### `BERTH_TO_PROSE_HANDOFF`
+```yaml
+BERTH_TO_PROSE_HANDOFF:
+  request: "store listing copy + What's New"
+  fields: ["title", "subtitle/short-desc", "description", "keywords", "whats_new"]
+  locales: ["[locale list]"]
+  constraints: "[char limits per store/field]; accurate to actual functionality"
+```
+
+### `BERTH_TO_GEAR_HANDOFF`
+```yaml
+BERTH_TO_GEAR_HANDOFF:
+  request: "upload automation"
+  ios: "fastlane deliver / Transporter; testflight track"
+  android: "fastlane supply / bundletool; target track"
+  metadata_source: "[path or console]"
+  notes: "Berth has validated compliance; Gear automates upload only"
+```
+
+---
+
+## Handoff Rules
+
+- Validate every incoming payload on receipt. If `privacy_manifest_present: false` (iOS) or Data safety is incomplete (Android), **reject back to Native** before proceeding — these block all tracks.
+- Berth never executes uploads or sets rollout percentages. Compliance verdict + submission plan in; rollout orchestration handed to `Launch`; upload mechanics handed to `Gear`.
+- Always include `policy_as_of` so downstream agents know the freshness of the compliance verdict.

--- a/berth/references/play-console.md
+++ b/berth/references/play-console.md
@@ -1,0 +1,91 @@
+# Google Play Console — Submission, Policies, Data Safety
+
+**Purpose:** Android submission workflow, Developer Program Policy map, Data safety, testing tracks, technical mandates, and common policy strikes.
+**Read when:** Auditing or submitting an Android build, or interpreting a Play policy strike.
+
+> **Verify before asserting.** Google revises policies, target API mandates, and testing-access requirements on a rolling basis. Confirm the current rule at the official source and state the "as of" date:
+> - Developer Program Policies: https://play.google.com/about/developer-content-policy/
+> - Data safety: https://support.google.com/googleplay/android-developer/answer/10787469
+> - Target API level: https://support.google.com/googleplay/android-developer/answer/11926878
+
+---
+
+## Submission Workflow (Play Console)
+
+1. **App record** — app name, default language, app/game category, free/paid.
+2. **App bundle** — upload **AAB** (Android App Bundle; required for new apps). Play generates per-device APKs via **Play App Signing** (Google holds the app signing key; you keep the upload key).
+3. **Store listing** — short & full description, app icon, feature graphic, phone/tablet screenshots, optional promo video.
+4. **App content (Policy declarations)** — Privacy policy URL, Ads, App access (login credentials for review), **Content rating (IARC questionnaire)**, Target audience & content, Data safety, Government apps, Financial features, Health apps, News.
+5. **Data safety form** — collected/shared data types, purposes, encryption-in-transit, deletion mechanism. Blocks submission across all tracks if absent.
+6. **Choose track** — internal / closed / open / production. Run **pre-launch report** (automated device testing).
+7. **Release** — set **staged rollout** percentage for production (this % lever is `Launch`'s, not Berth's). **Managed publishing** lets you batch and time-control going live.
+
+---
+
+## Testing Tracks
+
+| Track | Testers | Review | Use |
+|-------|---------|--------|-----|
+| Internal | ≤ 100 | Fast (minimal) | Quick internal builds |
+| Closed | Configurable lists | Reviewed | Alpha / structured QA |
+| Open | Public opt-in | Reviewed | Public beta |
+| Production | All users | Full review | Live |
+
+> **New personal developer accounts** (created from late 2023 onward) must run **closed testing with ≥ 12 testers for ≥ 14 continuous days** before requesting production access. This dominates first-release timelines — surface it at intake.
+
+---
+
+## Developer Program Policy Map (top-level)
+
+| Category | Examples |
+|----------|----------|
+| Restricted Content | Sexual content, hate speech, violence, illegal activities, gambling rules |
+| Privacy, Deception & Device Abuse | Data handling, Permissions & APIs that access sensitive info, deceptive behavior, malware, mobile unwanted software |
+| Monetization & Ads | Payments (Play Billing for in-app digital goods), subscriptions, disruptive ads, families ads |
+| Store Listing & Promotion | Metadata, ratings/reviews manipulation, impersonation |
+| Families | Designed for Families, target audience, content rating, ads SDK requirements |
+| Spam & Minimum Functionality | Broken/limited functionality, repetitive content |
+
+---
+
+## Common Policy Strikes / Rejections (Android)
+
+| Area | Reason | Remediation |
+|------|--------|-------------|
+| Data safety mismatch | Declared data practices don't match observed/SDK behavior | Reconcile the form with the actual data map (`Cloak`); declare all SDK-collected data. |
+| Sensitive permissions | Background location, All files access, SMS/Call Log, exact alarm, package visibility without justification | Remove if unused; file the declaration form; use scoped alternatives (Photo Picker, scoped storage). |
+| Broken functionality | Crashes in pre-launch report, login not working for reviewer | Fix; provide working App access credentials. |
+| Misleading store listing | Screenshots/description don't match app | Align listing with actual app. |
+| Account deletion | Account creation without in-app + web data deletion | Provide in-app deletion and a web deletion URL. |
+| IAP bypass | Digital goods sold outside Play Billing | Use Play Billing, or a qualifying external/alternative billing program. |
+| Families / content rating | Wrong target audience, ads SDK not Families-compliant | Re-run IARC, set correct audience, swap to compliant ads SDK. |
+
+---
+
+## Technical Mandates (verify current values)
+
+| Mandate | Note |
+|---------|------|
+| **AAB** | New apps must publish as Android App Bundle, not APK. |
+| **Play App Signing** | Required for new apps; safeguards the app signing key. |
+| **Target API level** | Must target within one year of the latest major Android release; annual deadline for new apps/updates with possible extensions. Below the threshold → can't submit updates (and discoverability limits for existing apps). |
+| **16 KB page size** | Apps targeting recent Android versions must support 16 KB memory page sizes (native libraries) by Google's stated deadline. |
+| **Permissions declarations** | Background location, All files access, exact alarm, photo/video, health, accessibility — each has a declaration/justification flow. |
+| **Account deletion** | In-app deletion + a publicly reachable web deletion URL for apps with account creation. |
+
+---
+
+## Permissions That Trigger Extra Review
+
+- `ACCESS_BACKGROUND_LOCATION` — declaration form + prominent disclosure.
+- `MANAGE_EXTERNAL_STORAGE` (All files access) — strong justification; prefer scoped storage / Photo Picker.
+- `SCHEDULE_EXACT_ALARM` — limited to eligible use cases.
+- `QUERY_ALL_PACKAGES` — limited to eligible use cases.
+- `READ_SMS` / `READ_CALL_LOG` — only for default handler use cases.
+- Health Connect, Accessibility API — purpose-restricted; misuse is a common strike.
+
+---
+
+## Pre-Launch Report
+
+Automated install + crawl on real devices: surfaces crashes, ANRs, accessibility, security, and performance issues *before* review. Treat its findings as pre-submission blockers.

--- a/berth/references/rejection-handbook.md
+++ b/berth/references/rejection-handbook.md
@@ -1,0 +1,79 @@
+# Rejection & Policy-Strike Handbook
+
+**Purpose:** Interpret a rejection or policy strike, classify it, produce remediation, and navigate Resolution Center / appeals.
+**Read when:** Running the `reject` recipe.
+
+---
+
+## Step 1 — Classify
+
+| Class | Signal | Path |
+|-------|--------|------|
+| **Metadata-fixable** | Screenshots/description/category/age-rating issue; nothing wrong with the binary | Fix metadata in the console; resubmit (often no new binary needed). |
+| **Binary-fixable** | Crash, missing capability (account deletion, login parity), permission misuse, privacy-declaration gap | Fix in the build (`Native`), update declarations, upload new build, resubmit. |
+| **Guideline dispute** | You believe the reviewer misread the app or the guideline | Reply in Resolution Center with evidence; escalate only with factual grounds. |
+
+> **Never resubmit unchanged.** Repeated identical submissions waste the review gate and can escalate scrutiny.
+
+---
+
+## Step 2 — Interpret the Reason
+
+- Apple cites a **guideline section** (e.g., 2.1, 4.3, 5.1.1(v)) — map it via `app-store-connect.md`.
+- Google cites a **policy** (e.g., Data safety, Background location, Families) — map it via `play-console.md`.
+- Extract the *specific* objection, not the category. "5.1.1" alone is not actionable; "missing in-app account deletion" is.
+
+---
+
+## Step 3 — Remediate
+
+Produce, per objection:
+1. The exact requirement (cite section/policy + the actionable rule).
+2. The concrete change (binary, declaration, or metadata).
+3. The owner (`Native` for code, `Berth` for declarations/metadata, `Cloak` for data-map corrections).
+4. Whether a new binary or only a resubmission is needed.
+
+---
+
+## Step 4 — Reply (Resolution Center / Play)
+
+Reply only when the change is done **or** you have a genuine factual clarification.
+
+**Good reply (clarification):**
+> "Account deletion is available at Settings → Account → Delete Account (screenshot attached). Steps to reach it from the demo account: …"
+
+**Good reply (dispute with grounds):**
+> "The flagged screen is gated behind the `pro_user` entitlement; the demo account `review@…` now has it enabled. Please re-test — the feature is fully functional, not placeholder."
+
+**Bad reply (avoid):** arguing the guideline is wrong without a fix or evidence; vague "please reconsider"; resubmitting with no change.
+
+---
+
+## Step 5 — Escalate (only with grounds)
+
+| Store | Escalation |
+|-------|-----------|
+| Apple | **App Review Board** appeal for a guideline-application dispute; or request a guideline interpretation. |
+| Google | **Policy appeal** via the Console policy-status / app-status flow; provide evidence of compliance or correction. |
+
+Escalation is for genuine misapplication, not for skipping a real fix.
+
+---
+
+## Common Rejection → Fix Quick Map
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| "We were unable to access the gated feature" | Missing/broken demo account | Provide working credentials + steps in App Review info / App access. |
+| "Privacy details / Data safety inaccurate" | Declared ≠ actual (often an SDK) | Reconcile with `Cloak` data map; declare SDK-collected data. |
+| iOS auto-rejected on upload | Missing Privacy Manifest Required-Reason API | Add `PrivacyInfo.xcprivacy` entries; ensure SDK manifests present. |
+| "App is a duplicate / spam" (4.3) | Template-farm or near-identical app | Differentiate substantively or consolidate. |
+| "Purchase must use IAP/Play Billing" | Digital goods via external payment | Route through store billing or qualify for an entitlement. |
+| Android "sensitive permission not justified" | Unused/over-broad permission | Remove, scope down, or file the declaration form. |
+| "Account creation requires deletion" | No in-app deletion path | Add deletion (iOS); add deletion + web URL (Android). |
+
+---
+
+## Repeat-Rejection Pattern
+
+If the same app is rejected ≥2× on related grounds, journal the pattern in `.agents/berth.md` (e.g., "this app's SDK X always triggers Data safety mismatch") so future submissions pre-empt it. Do not log routine one-off rejections.

--- a/berth/references/release-playbook.md
+++ b/berth/references/release-playbook.md
@@ -1,0 +1,90 @@
+# Submission Playbook — Tracks, Signing, Timeline
+
+**Purpose:** Sequence testing tracks, signing prerequisites, build upload, reviewer access, and a review-lead-time-aware submission timeline.
+**Read when:** Running the `submit` recipe or building the submission section of a readiness plan.
+
+> Berth owns *submission sequencing*. The staged-rollout *percentages*, Go/No-Go scoring, versioning, and rollback are `Launch`'s — hand them off, don't duplicate.
+
+---
+
+## Signing Prerequisites (verify before upload)
+
+| Platform | Check |
+|----------|-------|
+| iOS | Valid Apple Distribution certificate; App Store provisioning profile; correct bundle ID & entitlements (push, App Groups, associated domains, etc.); `ITSAppUsesNonExemptEncryption` set. |
+| Android | Upload key enrolled in **Play App Signing**; AAB built (not APK); `applicationId` matches the Console record; release signing config correct. |
+
+A signing/entitlement mismatch fails upload or processing — resolve before scheduling review.
+
+---
+
+## Testing-Track Sequence
+
+### iOS
+```
+Internal TestFlight (≤100, no Beta App Review)
+   → External TestFlight (≤10,000, Beta App Review ~lighter)
+   → App Review submission (full)
+   → Release: Manual | Auto | Phased (Launch decides the lever)
+```
+
+### Android
+```
+Internal testing (≤100, fast)
+   → Closed testing (alpha)        ← new personal accounts: ≥12 testers, ≥14 days
+   → Open testing (beta)
+   → Production (staged rollout %)  ← Launch decides the %
+```
+
+Pick the **lowest track** that satisfies the validation need. Always run the Android **pre-launch report** before promoting.
+
+---
+
+## Reviewer Access (mandatory if anything is gated)
+
+- Provide a **working demo account** (iOS: App Review Information; Android: App access credentials).
+- Note any region lock, feature flag default, or hardware dependency the reviewer needs.
+- If a feature is server-flag-gated, ensure the **reviewed state** is reachable — hiding the feature from review then enabling it remotely is a bait-and-switch rejection/termination risk.
+
+---
+
+## Review Lead Time (the fixed gate)
+
+| Store | Typical | Notes |
+|-------|---------|-------|
+| App Review (iOS) | 24–48h | Not guaranteed; expedited review is discretionary |
+| Beta App Review (TestFlight external) | hours–1 day | Lighter than App Review |
+| Play review (closed/open/prod) | hours–days | Varies; new-account closed-testing window dominates first release |
+
+**Rule:** treat review as a non-compressible block in the timeline. Never schedule a hard launch date that assumes faster-than-stated review.
+
+---
+
+## Submission Timeline (template)
+
+```
+T-? : Build uploaded & processed; signing verified
+T-? : Privacy declarations complete (BLOCKER gate)
+T-? : Internal track validated
+T-? : External / closed track (+ Beta App Review iOS / 14-day closed if new Android account)
+T-0 : Submit for App Review / promote to Production review
+T+review_lead_time : Approval
+T+approval : Release (hand rollout staging to Launch)
+```
+
+Output this with concrete dates and emit `BERTH_TO_LAUNCH_HANDOFF` so `Launch` attaches rollout %, halt triggers, and Go/No-Go.
+
+---
+
+## "What's New" / Release Notes
+
+- Berth authors/validates the **store-listing** "What's New" text (per locale), requesting copy from `Prose` and keyword sensitivity from `Growth`.
+- The engineering **CHANGELOG / stakeholder release notes** belong to `Launch`. Keep them aligned but don't duplicate ownership.
+
+---
+
+## Expedited / Hotfix Submission Path
+
+- iOS: request **Expedited Review** for critical fixes (discretionary); or ship a server-flag mitigation if the build is already approved.
+- Android: promote a fixed build through **Internal → Production** fast-track; halt the prior staged rollout first.
+- A mobile hotfix is still gated by review — the only instant lever is a **server-driven feature flag**, which is `Launch`'s rollback mechanism. Coordinate, don't reinvent.


### PR DESCRIPTION
## Summary
Adds **Berth**, a new skill agent that navigates App Store Connect and Google Play Console releases — review-guideline compliance, console submission workflow, store listing & privacy declarations, and rejection remediation. Scoped to fill the gap left by `launch` (rollout/versioning) without duplicating it.

## Changes
- `berth/SKILL.md` — agent spec (Trigger Guidance, Core Contract, Boundaries, 5 Recipes: ready/audit/privacy/submit/reject, AUTORUN, Nexus Hub, Output Contract)
- `berth/references/` (6) — app-store-connect, play-console, compliance-matrix, release-playbook, rejection-handbook, handoffs

All 7 files Essential / new. No existing files modified.

## Quality & Review
- Gauge normalization audit: 16/16 PASS (Health 100%)
- Judge content review: med findings addressed (review-lead-time consistency, IAP product readiness, verify-not-recall hedges, Berth↔Launch reciprocity note)
- Overlap with `launch`: ~22%, scoped via explicit handoff boundary

## Risk
Low — additive markdown only (no executable code, no secrets, no shared-file edits).

## Test plan
- [x] Gauge 16-item checklist
- [x] Judge content-quality review
- [ ] N/A — no CI configured in repo