### PR TITLE
docs: sync surface docs with current implementation (124 skills)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed — Anthropic Agent Skills official-spec alignment (2026-06-06)
+
+- **Directory convention**: `references/` (plural) → `reference/` (singular) across all 121 skill folders. Matches Anthropic official example layout. 5,048 path references updated across 375 .md files.
+- **Frontmatter `description`**: All 124 SKILL.md `description` fields rewritten to start with a gerund (`-ing` form) per official best-practices for model-invoked discovery. Third-person voice and exclusion rules preserved.
+
+### Changed — 9 skill renames for world-view consistency
+
+Non-metaphor / weak-metaphor names replaced with single-word metaphors that fit the established abstract-1-word convention:
+
+| Old → New | Rationale |
+|---|---|
+| `researcher` → `field` | role name → fieldwork metaphor |
+| `navigator` → `vector` | direct descriptor → directional intent |
+| `showcase` → `vitrine` | verb compound → display case |
+| `retain` → `bond` | English verb → relationship metaphor |
+| `comply` → `oath` | English verb → commitment |
+| `mentor` → `agora` | role name → learning marketplace |
+| `husk` → `cull` | weak fit → selective eradication |
+| `lure` → `bazaar` | manipulative → marketplace orchestration |
+| `spider` → `trawl` | industry literal → sweep metaphor |
+
+Git history preserved via `git mv`; all cross-references (PascalCase / paths / backticks / chain-DSL delimiters) updated. Tier 2 high-collision names (`schema` / `stream` / `growth` / `palette` / `pixel`) intentionally left as-is to avoid technical-term collisions.
+
+### Changed — Nexus Recipe refinements
+
+- `venture` Recipe row removed; alias only (≡ `package domain=startup`)
+- `bug` / `feature` / `refactor` / `optimize` chains surface conditional steps inline (`Sherpa?`, `Muse?`, `Radar?`, `Bolt (code) / Tuner (DB)` branch)
+- Hidden ~78 `classify`-only task types now explicitly documented in SKILL.md
+- Chain reference Source-of-Truth hierarchy declared in Routing Quick Start
+- 4 orphaned `.mmd` flow diagrams linked from corresponding recipe files
+
 ### Added
 
 #### New Agents

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This repository contains 145 specialized AI agents covering various aspects of s
 
 ## Agent Catalog
 
-> Category-by-category catalog for all 125 agents.
+> Category-by-category catalog for all 124 agents.
 
 ### Orchestration
 
@@ -57,7 +57,7 @@ This repository contains 145 specialized AI agents covering various aspects of s
 | **Gauge** | _"What gets measured gets managed. What gets audited gets normalized."_ - SKILL.md normalization auditor and self-evolving compliance agent. Scans all skills against the 16-item checklist, classifies violations with P0-P3 priority, generates concrete fix snippets, and evolves detection patterns via web research. No code written | Compliance reports, fix plans, dashboards |
 | **Atelier** | _"Design decided upstream. Assets produced downstream. atelier is the studio floor in between."_ - Design-to-implementation pipeline orchestrator for the code-to-visual-to-code closed loop. Coordinates Vision → Muse/Frame → Forge → Artisan → Vitrine → Canvas to deliver design extraction, prototypes, visual assets, slides, and production together while persisting a project design system across downstream agents | Design system package, integrated deliverables |
 | **Bazaar** | _"A landing page is one promise, one path, one decision. bazaar runs the studio that delivers all three."_ - Super-premium LP studio chain orchestrator. Composes Field → Cast → Pulse → Funnel → Vision → Saga → Compete → Muse → Flow → Artisan → Growth → Bolt → Judge → Launch into a recipe-selected, stage-gated pipeline (Discover → Audience → Strategy → Structure → Design → Build → Optimize → Verify → Launch) enforcing 6 craft axes — Design, Animation, Branding, Marketing, SEO, IA — each with explicit rubric and ship threshold | 6-axis-rubric-passed LP package, CVR-tuned production code, brand-coherent visuals, motion on tokens, schema-valid SEO, GEO citation-ready, analytics live |
-| **Compass** | _"When in doubt, ask Compass. It finds the right skill for you among 130+."_ - Skill ecosystem navigator and onboarding guide. Lists agents, recommends best fit for tasks, and helps newcomers discover the right specialist | Recommendations, agent maps |
+| **Compass** | _"When in doubt, ask Compass. It finds the right skill for you among 124."_ - Skill ecosystem navigator and onboarding guide. Lists agents, recommends best fit for tasks, and helps newcomers discover the right specialist | Recommendations, agent maps |
 
 ### Investigation & Planning (Non-coding)
 
@@ -800,7 +800,7 @@ skills/
 
 ### Single Agent Usage
 
-> Category-by-category examples for all 125 agents.
+> Category-by-category examples for all 124 agents.
 
 #### Orchestration
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,14 +1,14 @@
 # AI Agent Skills
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Agents](https://img.shields.io/badge/Agents-135-blue.svg)]()
+[![Agents](https://img.shields.io/badge/Agents-124-blue.svg)]()
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-🤖 135種類の専門AIエージェントチームによる協調開発を実現するスキルコレクション
+🤖 124種類の専門AIエージェントチームによる協調開発を実現するスキルコレクション
 
 ## ✨ Features
 
-- **135種類の専門エージェント** - バグ調査、テスト、セキュリティ、UI/UX、AI/ML、可観測性、インフラまで網羅
+- **124種類の専門エージェント** - バグ調査、テスト、セキュリティ、UI/UX、AI/ML、可観測性、インフラまで網羅
 - **Nexusオーケストレーター** - タスクを分析し最適なエージェントチェーンを自動設計
 - **プラットフォーム非依存** - Claude Code、Codex CLI、Antigravity CLI等で動作
 
@@ -35,7 +35,7 @@ git clone https://github.com/simota/agent-skills.git /path/to/your/skills
 
 ## 📚 概要
 
-このリポジトリには、ソフトウェア開発の様々な側面を専門とする135種類のAIエージェントが含まれています。各エージェントは特定のドメインに特化しており、**Nexus**オーケストレーターによって統括・連携されます。
+このリポジトリには、ソフトウェア開発の様々な側面を専門とする124種類のAIエージェントが含まれています。各エージェントは特定のドメインに特化しており、**Nexus**オーケストレーターによって統括・連携されます。
 
 ## エージェント一覧
 
@@ -57,7 +57,7 @@ git clone https://github.com/simota/agent-skills.git /path/to/your/skills
 | **Lore** | _"Forgotten lessons are lessons repeated. Institutional memory is the compound interest of experience."_ - エコシステム横断の知識統合・パターン抽出・伝播を担うメモリキュレーター。エージェントjournalから共通パターンを発見し、カタログ化して関連エージェントへ配信。知識の腐敗検出・ベストプラクティス伝播により制度的記憶を維持 | METAPATTERNS.md、知識インサイト |
 | **Atelier** | _"Design decided upstream. Assets produced downstream. atelier is the studio floor in between."_ - デザインから実装までを閉ループで繋ぐパイプラインオーケストレーター。Vision → Muse/Frame → Forge → Artisan → Vitrine → Canvas を統括し、デザイン抽出・プロトタイプ・ビジュアルアセット・スライド・本番実装をプロジェクトデザインシステムを永続化しながら一気通貫で提供 | デザインシステムパッケージ、統合成果物 |
 | **Bazaar** | _"A landing page is one promise, one path, one decision. bazaar runs the studio that delivers all three."_ - 超高品質LP制作スタジオチェーン・オーケストレーター。Field → Cast → Pulse → Funnel → Vision → Saga → Compete → Muse → Flow → Artisan → Growth → Bolt → Judge → Launch を、LP種別レシピと9段階の品質ゲート（Discover → Audience → Strategy → Structure → Design → Build → Optimize → Verify → Launch）で束ね、6つのクラフト軸（デザイン／アニメーション／ブランディング／マーケティング／SEO／IA）すべてにルーブリックと納品閾値を課したLPを納品 | 6軸ルーブリック通過済みLPパッケージ、CVR最適化された本番コード、ブランド整合性のあるビジュアル、トークン化されたモーション、スキーマ妥当性のあるSEO、AI検索引用対応GEO、計測稼働 |
-| **Compass** | _"When in doubt, ask Compass. It finds the right skill for you among 130+."_ - スキルエコシステムのナビゲーター・オンボーディングガイド。エージェントを一覧化し、タスクに最適な担当を推薦し、初心者が適切なスペシャリストを発見できるよう支援 | レコメンド、エージェントマップ |
+| **Compass** | _"When in doubt, ask Compass. It finds the right skill for you among 124+."_ - スキルエコシステムのナビゲーター・オンボーディングガイド。エージェントを一覧化し、タスクに最適な担当を推薦し、初心者が適切なスペシャリストを発見できるよう支援 | レコメンド、エージェントマップ |
 
 ### 調査・企画（コードを書かない）
 
@@ -793,7 +793,7 @@ skills/
 
 ### 単一エージェントの使用
 
-> カテゴリ別に全135エージェントの使用例を紹介します。
+> カテゴリ別に全124エージェントの使用例を紹介します。
 
 #### オーケストレーション
 

--- a/index.html
+++ b/index.html
@@ -3,16 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Agent Skills — 136超の専門AIエージェントが、あなたの開発チームになる</title>
-  <meta name="description" content="Claude Code / Codex CLI / Antigravity CLI で動作するオープンソースのAIエージェントエコシステム。バグ調査、テスト、セキュリティ、UI/UX、AI/ML、インフラまで網羅する136超の専門エージェント。">
-  <meta property="og:title" content="Agent Skills — 136超の専門AIエージェントが、あなたの開発チームになる">
-  <meta property="og:description" content="136超の専門AIエージェントが、あなたの開発チームになる。Claude Code / Codex CLI / Antigravity CLI 対応のオープンソースエコシステム。">
+  <title>Agent Skills — 124の専門AIエージェントが、あなたの開発チームになる</title>
+  <meta name="description" content="Claude Code / Codex CLI / Antigravity CLI で動作するオープンソースのAIエージェントエコシステム。バグ調査、テスト、セキュリティ、UI/UX、AI/ML、インフラまで網羅する124の専門エージェント。">
+  <meta property="og:title" content="Agent Skills — 124の専門AIエージェントが、あなたの開発チームになる">
+  <meta property="og:description" content="124の専門AIエージェントが、あなたの開発チームになる。Claude Code / Codex CLI / Antigravity CLI 対応のオープンソースエコシステム。">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://simota.github.io/agent-skills/">
   <meta property="og:locale" content="ja_JP">
   <meta property="og:site_name" content="Agent Skills">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Agent Skills — 136超の専門AIエージェントが、あなたの開発チームになる">
+  <meta name="twitter:title" content="Agent Skills — 124の専門AIエージェントが、あなたの開発チームになる">
   <meta name="twitter:description" content="バグ調査、セキュリティ、UI/UX、リリース管理まで。オープンソースのAIエージェントエコシステム。">
   <meta property="og:image" content="https://simota.github.io/agent-skills/og-image.png">
   <meta property="og:image:width" content="1200">
@@ -25,7 +25,7 @@
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Agent Skills",
-      "description": "Open-source AI agent ecosystem for Claude Code, Codex CLI, and Antigravity CLI. 136+ specialist agents covering investigation, implementation, testing, security, UI/UX, AI/ML, and infrastructure.",
+      "description": "Open-source AI agent ecosystem for Claude Code, Codex CLI, and Antigravity CLI. 124 specialist agents covering investigation, implementation, testing, security, UI/UX, AI/ML, and infrastructure.",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://simota.github.io/agent-skills/",
@@ -44,8 +44,8 @@
       "@context": "https://schema.org",
       "@type": "ItemList",
       "name": "AI Agent Catalog",
-      "description": "136+ specialist AI agents for software development",
-      "numberOfItems": 137,
+      "description": "124 specialist AI agents for software development",
+      "numberOfItems": 124,
       "itemListElement": [
         { "@type": "ListItem", "position": 1, "name": "Nexus", "description": "Team orchestrator that decomposes requests and auto-designs optimal agent chains" },
         { "@type": "ListItem", "position": 2, "name": "Scout", "description": "Bug investigation, root cause analysis (RCA), and reproduction step identification" },
@@ -910,7 +910,7 @@ a:focus-visible, .btn:focus-visible, .filter-btn:focus-visible, .lang-btn:focus-
       <span class="dot"></span>
       Open Source — MIT License
     </div>
-    <h1 data-i18n="hero.title"><span class="accent">136+</span>の専門AIエージェントが、<br>あなたの開発チームになる</h1>
+    <h1 data-i18n="hero.title"><span class="accent">124+</span>の専門AIエージェントが、<br>あなたの開発チームになる</h1>
     <p data-i18n="hero.desc">バグ調査、セキュリティ監査、UI/UX、リリース管理まで — 開発のあらゆる領域を専門エージェントがカバー。Claude Code・Codex CLI・Antigravity CLI で今日から使えるオープンソースエコシステム。</p>
     <div class="hero-copy-cmd">
       <code>git clone https://github.com/simota/agent-skills.git ~/.claude/skills</code>
@@ -1200,7 +1200,7 @@ a:focus-visible, .btn:focus-visible, .filter-btn:focus-visible, .lang-btn:focus-
     <div class="section-header fade-in">
       <div class="section-label">Agent Catalog</div>
       <h2 class="section-title" data-i18n="catalog.title">エージェントを探す</h2>
-      <p class="section-desc" data-i18n="catalog.desc">136超の専門エージェントをカテゴリやキーワードで絞り込めます</p>
+      <p class="section-desc" data-i18n="catalog.desc">124の専門エージェントをカテゴリやキーワードで絞り込めます</p>
       <div class="hero-cta" style="margin-top:24px; margin-bottom:0;">
         <a href="realm-directory/" class="btn btn-primary" data-i18n="catalog.directory">🏰 Realm Directory を探訪する</a>
       </div>
@@ -1322,7 +1322,7 @@ a:focus-visible, .btn:focus-visible, .filter-btn:focus-visible, .lang-btn:focus-
       </div>
     </div>
     <div style="text-align:center; margin-top:32px; padding-top:24px;">
-      <a href="#install" class="btn btn-primary" style="font-size:0.9rem;" data-i18n="footer.cta">136超のエージェントで開発を始める</a>
+      <a href="#install" class="btn btn-primary" style="font-size:0.9rem;" data-i18n="footer.cta">124のエージェントで開発を始める</a>
     </div>
     <div class="footer-bottom">
       MIT License &copy; simota
@@ -1659,7 +1659,7 @@ let currentLang = localStorage.getItem('lang') || 'ja';
 
 const TRANSLATIONS = {
   en: {
-    'hero.title': '<span class="accent">136+</span> Expert AI Agents<br>Become Your Dev Team',
+    'hero.title': '<span class="accent">124+</span> Expert AI Agents<br>Become Your Dev Team',
     'hero.desc': 'From bug investigation and security audits to UI/UX and release management — specialist agents cover every area of development. An open-source ecosystem for Claude Code, Codex CLI, and Antigravity CLI.',
     'hero.cta': 'Get Started',
     'hero.github': 'View on GitHub',
@@ -1697,7 +1697,7 @@ const TRANSLATIONS = {
     'subcmd.benefit3.title': 'Progressive Disclosure',
     'subcmd.benefit3.desc': 'Maps naturally to the three-tier hierarchy: L1 frontmatter → L2 SKILL.md → L3 references. Scales cleanly.',
     'catalog.title': 'Find an Agent',
-    'catalog.desc': 'Filter 136+ specialist agents by category or keyword',
+    'catalog.desc': 'Filter 124 specialist agents by category or keyword',
     'catalog.search': 'Search agents... (name, description, motto)',
     'catalog.empty': 'No matching agents found',
     'platforms.title': 'Multi-Platform Support',
@@ -1721,7 +1721,7 @@ const TRANSLATIONS = {
     'hero.cta': 'Learn How',
     'social.star': 'GitHub Star',
     'social.platform': 'Works with Claude Code / Codex CLI / Antigravity CLI',
-    'footer.cta': 'Start building with 136+ agents',
+    'footer.cta': 'Start building with 124+ agents',
     'terminal.cmd': '/Nexus Fix the login bug',
     'terminal.analyzing': 'Analyzing task...',
     'terminal.chain': 'Chain designed:',
@@ -1899,15 +1899,15 @@ function setLanguage(lang) {
   const ogTitleEl = document.querySelector('meta[property="og:title"]');
   const ogDescEl = document.querySelector('meta[property="og:description"]');
   if (lang === 'en') {
-    titleEl.textContent = 'Agent Skills — 136+ Expert AI Agents Become Your Dev Team';
-    descEl.content = 'An open-source AI agent ecosystem for Claude Code, Codex CLI, and Antigravity CLI. 136+ specialist agents covering bug investigation, testing, security, UI/UX, AI/ML, and infrastructure.';
+    titleEl.textContent = 'Agent Skills — 124+ Expert AI Agents Become Your Dev Team';
+    descEl.content = 'An open-source AI agent ecosystem for Claude Code, Codex CLI, and Antigravity CLI. 124 specialist agents covering bug investigation, testing, security, UI/UX, AI/ML, and infrastructure.';
     ogTitleEl.content = 'Agent Skills — AI Agent Ecosystem';
-    ogDescEl.content = '136+ expert AI agents become your dev team. An open-source agent ecosystem.';
+    ogDescEl.content = '124+ expert AI agents become your dev team. An open-source agent ecosystem.';
   } else {
-    titleEl.textContent = 'Agent Skills — 136超の専門AIエージェントが、あなたの開発チームになる';
-    descEl.content = 'Claude Code / Codex CLI / Antigravity CLI で動作するオープンソースのAIエージェントエコシステム。バグ調査、テスト、セキュリティ、UI/UX、AI/ML、インフラまで網羅する136超の専門エージェント。';
+    titleEl.textContent = 'Agent Skills — 124の専門AIエージェントが、あなたの開発チームになる';
+    descEl.content = 'Claude Code / Codex CLI / Antigravity CLI で動作するオープンソースのAIエージェントエコシステム。バグ調査、テスト、セキュリティ、UI/UX、AI/ML、インフラまで網羅する124の専門エージェント。';
     ogTitleEl.content = 'Agent Skills — AI Agent Ecosystem';
-    ogDescEl.content = '136超の専門AIエージェントが、あなたの開発チームになる。オープンソースのエージェントエコシステム。';
+    ogDescEl.content = '124の専門AIエージェントが、あなたの開発チームになる。オープンソースのエージェントエコシステム。';
   }
 
   // Re-render dynamic content


### PR DESCRIPTION
## Summary

Sync README / index.html / CHANGELOG / repo metadata with the post-merge implementation state.

## Changes

- **README.md / README_ja.md**: skill count copy and badges updated (135 / 130+ / 125 → 124)
- **index.html**: title, meta description, OG/Twitter, structured-data `numberOfItems` (137 → 124)
- **CHANGELOG.md**: `[Unreleased]` entry for Official Spec Alignment work (reference/ rename, gerund descriptions, 9-skill rename, Nexus Recipe refinements)
- **GitHub repo metadata**:
  - description rewritten to reflect spec-alignment + Nexus orchestration
  - topics adjusted within 20-limit: drop `antigravity` / `developer-tools` / `prompt-library`; add `agent-skills` / `subagent` / `anthropic`

## Test plan

- [x] README counts consistent across both languages
- [x] index.html structured data renders 124
- [x] gh repo view shows updated description + topic set