### PR TITLE
docs(cli): require real pty for headless agy agent spawns

### DIFF
--- a/_common/CLI_COMPATIBILITY.md
+++ b/_common/CLI_COMPATIBILITY.md
@@ -205,7 +205,7 @@ Surface these in any skill that targets agy. Each is sourced from the official G
 | MCP `url` → `serverUrl` rename | Silent connection failure | Always document `serverUrl` in MCP setup snippets |
 | Skill description vague → tool bloat | 40-50K token overhead | Keep `description:` ≤2 sentences with explicit trigger keywords |
 | `agy plugin import gemini` does not migrate custom themes | Cosmetic regression | Note in migration guides |
-| **Headless stdout flush bug — `-p`/`--print` emits NOTHING to non-TTY stdout even on success** (official issue #115 "Can't Capture CLI Output", OPEN; root cause per gemini-cli #27466: `text_drip.go` renders to TUI but never flushes to a non-TTY stdout; unfixed through v1.0.5) | `agy ... --print "..." > log.txt` produces an empty file with `exit 0` — a SUCCESSFUL run is indistinguishable from a silent failure when reading stdout; redirect/`tee` capture nothing | **Never use stdout as the deliverable channel.** Apply the §9.2 file-handoff protocol (prompt-mandated absolute-path artifact + sentinel + verification chain + transcript fallback). Pseudo-TTY reattach (`script -q /dev/null agy ...`) partially mitigates but artifact verification is still mandatory |
+| **agy requires a TTY + headless stdout-flush bug** — `-p`/`--print` hangs with no controlling terminal AND emits NOTHING to non-TTY stdout even on success (TTY requirement verified 2026-06-08 agy 1.0.6; stdout flush = official issue #115 "Can't Capture CLI Output", OPEN; root cause per gemini-cli #27466: `text_drip.go` renders to TUI but never flushes to a non-TTY stdout) | From a socket-stdin shell (Claude Code `Bash`, CI, cron): bare `agy -p` **hangs to `exit 124`** (empty stdout, no artifact, no log) and `script -q /dev/null agy ...` dies with `tcgetattr/ioctl: Operation not supported on socket` — both are silent-output | **Never use stdout as the deliverable channel, and give agy a real pty.** Allocate the pty via `python3 -c 'import pty; pty.spawn([...])'` (the `script` reattach does NOT work here), then apply the §9.2 file-handoff protocol (prompt-mandated absolute-path artifact + sentinel + verification chain + transcript fallback). Canonical block: §9.2 |
 | **Bare file paths in prompts trigger silent subagent timeouts** | Headless `agy -p` exits with `exit 0` + empty stdout when given paths without `@`; main agent delegates file reads to a subagent that dies at the 60s cap (v1.0.2 changelog: "restricted the default 60-second interaction timeout specifically to subagents") | **Always use `@<path>` syntax** to inject file context into the main agent; combine with `--log-file` + post-run grep per `_common/MULTI_ENGINE_RECIPE.md §3.5` |
 | **`--output-format json` availability is INCONSISTENT across installs** (2026-06 re-verification: community guide demonstrates it, but a commenter on the same guide reports "flag not defined" error; no JSON schema documented anywhere; official issue #7 notes `stream-json` is Gemini CLI legacy, not agy) | A spawn script depending on the flag may hard-fail on some installs, or succeed with an unparseable schema | **Do not depend on the flag for output capture.** Request the structured JSON inside the §9.2 artifact file via the prompt instead; if the flag is used at all, treat failure as non-fatal |
 | **`--print-timeout` default 5min on heavy reviews** | Long multi-file syntheses may exceed default; main agent (not subagent) terminates | Pass `--print-timeout 15m` or larger for documents >1000 lines or multi-file comparisons |
@@ -260,9 +260,13 @@ Continuing the spawn now …
 
 ### 9.2. agy Headless Output-Capture Protocol (canonical)
 
-> Single source of truth for capturing deliverables from `agy -p` spawns. Verified 2026-06 against agy v1.0.5. All skills that spawn agy headless MUST follow this protocol instead of reading stdout.
+> Single source of truth for capturing deliverables from `agy -p` spawns. Verified 2026-06 against agy v1.0.5; **agy-as-agent TTY convention re-verified 2026-06-08 against agy 1.0.6 / codex 0.137.0 / Claude Code 2.1.168 (macOS)**. All skills that spawn agy headless MUST follow this protocol instead of reading stdout.
 
-**Why**: agy `-p`/`--print` mode has a non-TTY stdout-flush bug (official issue #115, OPEN; root cause `text_drip.go` per gemini-cli #27466) — the run authenticates, gets the model response, and exits 0 **without writing it to stdout** when stdout is a pipe or file. Unfixed through v1.0.5; no changelog entry targets it. Redirection (`>`), `tee`, and `tail` capture nothing. Therefore `exit 0 + empty stdout` no longer implies RUNTIME-BROKEN — it is also what a *successful* run looks like. Capture must move to disk artifacts.
+> **⚠ MANDATORY CONVENTION — read before spawning agy or codex as an agent.** When agy/codex are driven as sub-agents from an orchestrator's shell (Claude Code `Bash`, CI runner, cron — i.e. **no controlling terminal, socket stdin**), the silent-output failure is reproducible and has a verified fix per engine:
+> - **agy REQUIRES a TTY.** A bare `agy -p "..." > file` **hangs to timeout** (`exit 124`, empty stdout, **no artifact, no log file at all**) — a textbook silent-output. The previously-recommended pseudo-TTY reattach `script -q /dev/null agy ...` **also fails** in this context (`script: tcgetattr/ioctl: Operation not supported on socket`). The **only** verified mitigation is allocating a real pty via **`python3 -c 'import pty; pty.spawn([...])'`** (see canonical block below) — with the pty, agy runs, writes the artifact + sentinel, and even flushes stdout.
+> - **codex is robust** with `-o <abs path>`: foreground *and* fully-detached (`start_new_session` / no controlling tty) + non-trivial prompts both completed correctly (#19945 did NOT reproduce on 0.137.0 when `-o` is the capture channel). Always pass `-o` and treat the artifact (not stdout, not exit code) as the source of truth.
+
+**Why (agy)**: agy `-p`/`--print` mode has two compounding non-TTY failures. (1) **TTY requirement** — agy's runtime opens `/dev/tty`; with no controlling terminal it stalls until `--print-timeout`/the caller's timeout and dies leaving nothing (empty stdout, no artifact, no `--log-file` written). (2) **stdout-flush bug** (official issue #115, OPEN; root cause `text_drip.go` per gemini-cli #27466) — even when it does run, it exits 0 **without writing the response to a piped/redirected stdout**. Unfixed through v1.0.6. Therefore `exit 0/124 + empty stdout` does NOT imply RUNTIME-BROKEN and an empty stdout is also what a *successful* run looks like. Capture must move to disk artifacts, and the process must be given a pty.
 
 **Capture channels, in order of authority**:
 
@@ -286,10 +290,17 @@ SLUG="<task-slug>"
 OUT="/tmp/agy-${SLUG}.md"          # ABSOLUTE path — agy sandbox cwd ≠ orchestrator cwd
 LOG="/tmp/agy-${SLUG}.log"
 rm -f "$OUT"
-# Pseudo-TTY reattach dodges the non-TTY flush bug for the status line (macOS/BSD syntax;
-# Linux: script -qfc "agy -p ... " /dev/null). Exit code is NOT trusted either way.
-script -q /dev/null agy -p "$(cat /tmp/prompt.md)" --dangerously-skip-permissions \
-  --log-file "$LOG" --print-timeout 15m >/dev/null 2>&1 || true
+# agy REQUIRES a TTY. In a no-controlling-terminal / socket-stdin context (Claude Code's Bash
+# tool, CI, cron) a bare `agy -p` hangs to timeout (empty stdout, no artifact, no log), and
+# `script -q /dev/null agy ...` fails immediately ("tcgetattr/ioctl: Operation not supported
+# on socket"). Allocate a real pty via python pty.spawn — the ONLY mitigation verified in that
+# context (2026-06-08, agy 1.0.6). Exit code is NOT trusted; the artifact below is the truth.
+python3 - "$LOG" <<'PY' || true
+import pty, sys
+log = sys.argv[1]
+prompt = open("/tmp/prompt.md").read()
+pty.spawn(["agy","-p",prompt,"--dangerously-skip-permissions","--log-file",log,"--print-timeout","15m"])
+PY
 
 # Verification chain — ALL must pass before the artifact is trusted
 if [ -s "$OUT" ] && grep -q '<<<END_OF_OUTPUT>>>' "$OUT"; then

--- a/_common/MULTI_ENGINE_RECIPE.md
+++ b/_common/MULTI_ENGINE_RECIPE.md
@@ -254,9 +254,14 @@ Some CLIs report runtime failures (quota exhaustion, auth expiry, executor error
 SLUG="<task-slug>"
 OUT="/tmp/agy-${SLUG}.md"; LOG="/tmp/agy-${SLUG}.log"
 rm -f "$OUT"
-# stdout is NOT captured — agy -p never flushes to non-TTY stdout (issue #115, unfixed v1.0.5)
-script -q /dev/null agy -p "$(cat /tmp/prompt.md)" --dangerously-skip-permissions \
-  --log-file "$LOG" --print-timeout 15m >/dev/null 2>&1 || true
+# agy REQUIRES a TTY: from a socket-stdin shell `agy -p` hangs silently and `script -q /dev/null`
+# fails ("Operation not supported on socket"). Give it a real pty via python pty.spawn (§9.2).
+# stdout is NOT the deliverable channel either — issue #115 (unfixed v1.0.6).
+python3 - "$LOG" <<'PY' || true
+import pty, sys
+pty.spawn(["agy","-p",open("/tmp/prompt.md").read(),"--dangerously-skip-permissions",
+           "--log-file",sys.argv[1],"--print-timeout","15m"])
+PY
 if [ -s "$OUT" ] && grep -q '<<<END_OF_OUTPUT>>>' "$OUT"; then
   echo "OK: deliverable at $OUT"
 else
@@ -362,14 +367,18 @@ Engine-specific invocation:
 codex exec --full-auto -o "/tmp/codex-<slug>.md" "$(cat /tmp/prompt.md)"
 [ -s "/tmp/codex-<slug>.md" ] || echo "VERDICT: codex RUNTIME-BROKEN (empty artifact despite RC=$?)"
 
-# Antigravity (subagent runs this) — file-handoff capture MANDATORY (stdout never flushes
-# to non-TTY: issue #115, unfixed v1.0.5). Prompt must end with the §9.2 OUTPUT PROTOCOL
-# block: write JSON deliverable to $OUT (absolute path) + final-line sentinel <<<END_OF_OUTPUT>>>.
+# Antigravity (subagent runs this) — agy needs a real pty (use python pty.spawn, NOT
+# `script -q /dev/null` which fails on socket stdin) + file-handoff capture MANDATORY (stdout
+# never flushes to non-TTY: issue #115, unfixed v1.0.6). Prompt must end with the §9.2 OUTPUT
+# PROTOCOL block: write JSON deliverable to $OUT (absolute path) + final-line sentinel <<<END_OF_OUTPUT>>>.
 SLUG="<task-slug>"
 OUT="/tmp/agy-${SLUG}.json"; LOG="/tmp/agy-${SLUG}.log"
 rm -f "$OUT"
-script -q /dev/null agy -p "$(cat /tmp/prompt.md)" --dangerously-skip-permissions \
-  --log-file "$LOG" --print-timeout 15m >/dev/null 2>&1 || true
+python3 - "$LOG" <<'PY' || true
+import pty, sys
+pty.spawn(["agy","-p",open("/tmp/prompt.md").read(),"--dangerously-skip-permissions",
+           "--log-file",sys.argv[1],"--print-timeout","15m"])
+PY
 if ! { [ -s "$OUT" ] && grep -q '<<<END_OF_OUTPUT>>>' "$OUT"; }; then
   grep -E "RESOURCE_EXHAUSTED|Resets in|error getting token|agent executor error|unexpected end of JSON" "$LOG" | head -5
   echo "VERDICT: agy RUNTIME-BROKEN — see §Engine Runtime Failure Detection (try transcript fallback per CLI_COMPATIBILITY §9.2 first)"

--- a/_common/SUBAGENT.md
+++ b/_common/SUBAGENT.md
@@ -171,8 +171,13 @@ codex exec --full-auto -o "/tmp/codex-<slug>.md" "$(cat /tmp/prompt.md)"
 SLUG="<task-slug>"
 OUT="/tmp/agy-${SLUG}.md"; LOG="/tmp/agy-${SLUG}.log"
 rm -f "$OUT"
-script -q /dev/null agy -p "$(cat /tmp/prompt.md)" --dangerously-skip-permissions \
-  --log-file "$LOG" --print-timeout 15m >/dev/null 2>&1 || true
+# agy REQUIRES a TTY: from a socket-stdin shell `agy -p` hangs silently and `script -q /dev/null`
+# fails ("Operation not supported on socket"). Give it a real pty via python pty.spawn (§9.2).
+python3 - "$LOG" <<'PY' || true
+import pty, sys
+pty.spawn(["agy","-p",open("/tmp/prompt.md").read(),"--dangerously-skip-permissions",
+           "--log-file",sys.argv[1],"--print-timeout","15m"])
+PY
 if [ -s "$OUT" ] && grep -q '<<<END_OF_OUTPUT>>>' "$OUT"; then
   echo "OK: deliverable at $OUT"
 else

--- a/judge/reference/antigravity-review-usage.md
+++ b/judge/reference/antigravity-review-usage.md
@@ -311,17 +311,21 @@ Always pair the prompt with `--dangerously-skip-permissions` for headless runs u
 
 ### Silent Failure Detection
 
-`agy` silently swallows several runtime-fatal errors to its log file while exiting 0 with empty stdout — quota exhaustion (`RESOURCE_EXHAUSTED` 429 with a `Resets in NhNm` window), OAuth token expiry, upstream model unavailability, corrupt `mcp_config.json`. **Additionally (unfixed through v1.0.5, issue #115): `agy -p` never flushes its response to a non-TTY stdout, so a SUCCESSFUL review also produces `exit 0 + empty stdout` when piped.** Capture must therefore use the file-handoff protocol (`_common/CLI_COMPATIBILITY.md §9.2`), not stdout.
+`agy` silently swallows several runtime-fatal errors to its log file while exiting 0 with empty stdout — quota exhaustion (`RESOURCE_EXHAUSTED` 429 with a `Resets in NhNm` window), OAuth token expiry, upstream model unavailability, corrupt `mcp_config.json`. **Additionally: agy REQUIRES a TTY — from a socket-stdin shell (Claude Code `Bash`, CI, cron) `agy -p` hangs to `exit 124` with no artifact/log, and `script -q /dev/null agy ...` fails with `tcgetattr/ioctl: Operation not supported on socket` (verified 2026-06-08, agy 1.0.6). And (unfixed through v1.0.6, issue #115) `agy -p` never flushes its response to a non-TTY stdout, so a SUCCESSFUL review also produces `exit 0 + empty stdout` when piped.** Capture must therefore give agy a real pty (`python3 pty.spawn`) and use the file-handoff protocol (`_common/CLI_COMPATIBILITY.md §9.2`), not stdout.
 
-**Mandatory pattern for headless invocations** (prompt must mandate the artifact write per §9.2):
+**Mandatory pattern for headless invocations** (prompt must mandate the artifact write per §9.2; agy gets a real pty via python pty.spawn — `script -q /dev/null` does NOT work here):
 
 ```bash
 OUT="/tmp/agy-review.md"; LOG="/tmp/agy-review.log"
 rm -f "$OUT"
 # Prompt ends with: "Write your COMPLETE findings to the absolute path /tmp/agy-review.md,
 #   final line <<<END_OF_OUTPUT>>>; print only a one-line status to stdout."
-script -q /dev/null agy -p "<prompt>" --dangerously-skip-permissions --log-file "$LOG" \
-  --print-timeout 15m >/dev/null 2>&1 || true
+# Write the prompt to /tmp/agy-review.prompt first, then:
+python3 - "$LOG" <<'PY' || true
+import pty, sys
+pty.spawn(["agy","-p",open("/tmp/agy-review.prompt").read(),"--dangerously-skip-permissions",
+           "--log-file",sys.argv[1],"--print-timeout","15m"])
+PY
 
 if ! { [ -s "$OUT" ] && grep -q '<<<END_OF_OUTPUT>>>' "$OUT"; }; then
   # Fallback: transcript harvest, then log grep (full chain: CLI_COMPATIBILITY §9.2)

--- a/nexus/SKILL.md
+++ b/nexus/SKILL.md
@@ -251,7 +251,9 @@ Full per-CLI prereqs, runtime notes, silent-failure mitigations, and the verifie
 |-----|----|----|----|-----------|
 | **Claude Code** | `Agent(... mode: bypassPermissions)` | `Agent(... run_in_background: true)` | `Agent("You are Rally...")` | `Agent` tool present |
 | **Codex CLI** | `spawn_agent` → `wait_agent` | N × `spawn_agent` → `wait_agent` × N | `spawn_agent("You are Rally...")` | `multi_agent = true` + `[agents] max_depth >= 2` |
-| **agy** | `/agent <name>` (TUI) or `agy -p --dangerously-skip-permissions` (headless) | Multiple `/agent` (async, `/tasks`) | Plugin team pack | TUI main session or OS-level isolation; artifact file capture (NOT stdout) |
+| **agy** | `/agent <name>` (TUI) or `agy -p --dangerously-skip-permissions` (headless) | Multiple `/agent` (async, `/tasks`) | Plugin team pack | TUI main session or OS-level isolation; **headless from a socket-stdin shell MUST allocate a real pty (`python3 pty.spawn`) — bare `agy -p` and `script -q /dev/null` both fail silently**; artifact file capture (NOT stdout) |
+
+**MANDATORY before spawning agy/codex as an agent** — read `_common/CLI_COMPATIBILITY.md §9.2` (agy: real pty via `python3 pty.spawn` + artifact/sentinel capture, NEVER stdout) and §9.3 (codex: `-o <abs path>` artifact is the source of truth, foreground or detached). These are silent-output regressions, not edge cases.
 
 Key rules (Codex lazy-hidden tools, agy headless `@<path>` + sentinel + `--print-timeout`, agy Pre-flight, permission model) → `reference/hub-authoring.md` § Execution-Layer Key Rules.
 

--- a/nexus/reference/execution-layers.md
+++ b/nexus/reference/execution-layers.md
@@ -73,7 +73,8 @@ The `exit 0 + empty stdout` pattern detected by `_common/MULTI_ENGINE_RECIPE.md 
 
 | Root cause | Mechanism | Mitigation |
 |------------|-----------|------------|
-| **Non-TTY stdout flush bug (affects SUCCESSFUL runs too)** | `agy -p` renders output via TUI drip (`text_drip.go`) and never flushes to a non-TTY stdout — redirection/`tee` capture nothing even when the model responded (official issue #115, OPEN; unfixed through v1.0.5) | **Never use stdout as the deliverable channel.** Mandate an absolute-path artifact write + sentinel in the prompt per `_common/CLI_COMPATIBILITY.md §9.2`; pseudo-TTY reattach (`script -q /dev/null agy ...`) helps the status line but artifact verification stays mandatory |
+| **TTY requirement (silent hang from socket-stdin shells)** | agy opens `/dev/tty`; spawned from a no-controlling-terminal shell (Claude Code `Bash`, CI, cron) `agy -p` hangs to `exit 124` with empty stdout, **no artifact, and no log file**. `script -q /dev/null agy ...` also fails (`tcgetattr/ioctl: Operation not supported on socket`). Verified 2026-06-08, agy 1.0.6 | **Give agy a real pty** via `python3 -c 'import pty; pty.spawn([...])'` — the ONLY mitigation verified in that context (the `script` reattach does NOT work). Canonical block: `_common/CLI_COMPATIBILITY.md §9.2` |
+| **Non-TTY stdout flush bug (affects SUCCESSFUL runs too)** | `agy -p` renders output via TUI drip (`text_drip.go`) and never flushes to a non-TTY stdout — redirection/`tee` capture nothing even when the model responded (official issue #115, OPEN; unfixed through v1.0.6) | **Never use stdout as the deliverable channel.** Mandate an absolute-path artifact write + sentinel in the prompt per `_common/CLI_COMPATIBILITY.md §9.2`; combined with the pty wrapper above, artifact verification stays mandatory |
 | **File path written as plain string** | agy treats `docs/foo.md` (no `@`) as literal text; main agent delegates the read to an internal subagent | **Always use `@<path>` syntax** to inject file context directly into the main agent (e.g. `Compare @docs/a.md and @docs/b.md ...`) |
 | **Internal subagent 60s timeout** | v1.0.2 changelog restricts the 60s timeout to subagents only (main agent is no longer capped); long-file reads via delegated subagents still die silently | `@` syntax avoids subagent delegation entirely; for unavoidable delegation, split prompt into multiple smaller `agy -p` calls |
 | **`--print-timeout` exceeded** | Default 5min on the main agent's wait; long syntheses can hit it | Pass `--print-timeout 15m` (or appropriate) for heavy reviews |
@@ -81,10 +82,10 @@ The `exit 0 + empty stdout` pattern detected by `_common/MULTI_ENGINE_RECIPE.md 
 
 **`--output-format json` status (re-verified 2026-06, v1.0.5)**: availability is **inconsistent across installs** — demonstrated in a community guide, but "flag not defined" errors are reported on the same guide, and no JSON schema is documented anywhere. **Do not depend on it.** Request structured JSON inside the §9.2 artifact file instead.
 
-**Recommended headless template** (full protocol + verification chain: `_common/CLI_COMPATIBILITY.md §9.2`):
+**Recommended headless template** (full protocol + verification chain: `_common/CLI_COMPATIBILITY.md §9.2`). **agy needs a real pty — use `python3 pty.spawn`, NOT `script -q /dev/null`** (the latter fails with `tcgetattr/ioctl: Operation not supported on socket` from Claude Code's Bash tool):
 ```bash
 SLUG="<task-slug>"
-script -q /dev/null agy -p --dangerously-skip-permissions "$(cat <<EOF
+cat > /tmp/agy-${SLUG}.prompt <<EOF
 [Role and task]
 
 Primary: @<path>
@@ -95,7 +96,13 @@ MANDATORY OUTPUT PROTOCOL:
 - End that file with a final line containing exactly: <<<END_OF_OUTPUT>>>
 - To stdout, print only a single status line: DONE /tmp/agy-${SLUG}.md
 EOF
-)" --print-timeout 15m --log-file /tmp/agy-${SLUG}.log >/dev/null 2>&1 || true
+python3 - "$SLUG" <<'PY' || true
+import pty, sys
+slug = sys.argv[1]
+prompt = open(f"/tmp/agy-{slug}.prompt").read()
+pty.spawn(["agy","-p",prompt,"--dangerously-skip-permissions",
+           "--print-timeout","15m","--log-file",f"/tmp/agy-{slug}.log"])
+PY
 # Then run the §9.2 verification chain: [ -s /tmp/agy-${SLUG}.md ] && sentinel grep;
 # fallback 1 = transcript harvest (brain/<conv-id>/.../transcript.jsonl last PLANNER_RESPONSE);
 # fallback 2 = --log-file grep → RUNTIME-BROKEN. Typed retry: max 1.


### PR DESCRIPTION
## Summary
agy をオーケストレータのシェル（Claude Code `Bash` / CI / cron = 制御端末なし・socket stdin）から headless 実行すると silent-output になる問題を、実環境で再現・診断し、規約として全 SoT に反映。

## Root cause (verified 2026-06-08, agy 1.0.6 / codex 0.137.0 / Claude Code 2.1.168, macOS)
- **agy は TTY を要求する。** 素の `agy -p "..." > file` は `exit 124` でハング（stdout 空・artifact 無し・ログ無し）。
- 従来推奨の `script -q /dev/null agy ...` も socket stdin で失敗（`tcgetattr/ioctl: Operation not supported on socket`）。
- **唯一効く緩和は `python3 pty.spawn` による本物の pty 割り当て。** pty 経由なら artifact + sentinel を書き、stdout もフラッシュされる（実証済み）。
- **codex は堅牢:** `-o <絶対パス>` artifact を真実とすれば foreground/detach どちらも正常（#19945 は 0.137.0 + `-o` で再現せず）。

## Changes
| File | 分類 | 内容 |
|------|------|------|
| `_common/CLI_COMPATIBILITY.md` | Essential | §9.2 に MANDATORY CONVENTION バナー + 正典スニペット pty 化、§9 表更新 |
| `nexus/SKILL.md` | Essential | 実行レイヤ表に pty 必須明記 + spawn 前必読の規約行 |
| `nexus/reference/execution-layers.md` | Essential | 根本原因表に TTY 行追加 + headless テンプレート pty 化 |
| `_common/MULTI_ENGINE_RECIPE.md` | Supporting | §3.5 / 並列スケルトンのスニペット pty 化 |
| `_common/SUBAGENT.md` | Supporting | Dispatch スニペット pty 化 |
| `judge/reference/antigravity-review-usage.md` | Supporting | silent failure 検出 + 起動スニペット pty 化 |

## Risk
Low — docs のみ。全 `script -q /dev/null agy` 実コマンドを `python3 pty.spawn` に置換（残存は「不可」注記のみ）。正典スニペットは実環境でそのまま実行し PONG + sentinel 取得を確認済み。

## Test plan
- [x] 正典スニペット（`/tmp/prompt.md` 読込 → pty.spawn → 検証チェーン）を実行 → artifact + sentinel 取得成功
- [x] codex `-o` artifact（foreground / detached）で正常完了を確認
- [ ] skill-lint CI green